### PR TITLE
[MDH-37] feat : 글로벌 예외 핸들러 작성

### DIFF
--- a/src/main/java/com/mdh/devtable/global/error/ValidationError.java
+++ b/src/main/java/com/mdh/devtable/global/error/ValidationError.java
@@ -1,0 +1,17 @@
+package com.mdh.devtable.global.error;
+
+import lombok.Builder;
+import org.springframework.validation.FieldError;
+
+@Builder
+public record ValidationError(
+        String field,
+        String message
+) {
+    public static ValidationError of(final FieldError fieldError) {
+        return ValidationError.builder()
+                .field(fieldError.getField())
+                .message(fieldError.getDefaultMessage())
+                .build();
+    }
+}

--- a/src/main/java/com/mdh/devtable/global/handler/GlobalControllerAdvice.java
+++ b/src/main/java/com/mdh/devtable/global/handler/GlobalControllerAdvice.java
@@ -1,0 +1,31 @@
+package com.mdh.devtable.global.handler;
+
+import com.mdh.devtable.global.ApiResponse;
+import com.mdh.devtable.global.error.ValidationError;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.net.URI;
+
+@RestControllerAdvice
+public class GlobalControllerAdvice {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ApiResponse<ProblemDetail> handleValidation(MethodArgumentNotValidException e, HttpServletRequest request) {
+        var uri = request.getRequestURI();
+        var problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, e.getMessage());
+        problemDetail.setInstance(URI.create(uri));
+        problemDetail.setTitle("MethodArgumentNotValidException");
+        problemDetail.setProperty("validationError", e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(ValidationError::of)
+                .toList());
+
+        return ApiResponse.fail(HttpStatus.BAD_REQUEST.value(), problemDetail);
+    }
+}


### PR DESCRIPTION
## 🖊️ 1. Changes

- 글로벌 예외 핸들러 작성

## 🖼️ 2. Screenshot

-

## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer

- 예시 응답은 아래와 같음
```
{
    "type": "http://localhost:8080/errors/customer-not-found", // 예외 발생 후 리다이렉트 할 URI
    "title": "Customer Not Found", // 예외 제목
    "status": 404, // 응답 상태 코드
    "detail": "Customer 1000 not found!", // 예외 메시지
    "instance": "/api/v1/customers/1000", // 예외가 발생한 URI
    "customerId": 1000 // 추가적으로 클라이언트에게 전달 할 properties
}
```

## ✅ 5. Plans
- [ ] - 
- [ ] - 