### PR TITLE
[MDH-9] 매장 웨이팅 엔티티 작성 및 테스트

### DIFF
--- a/.idea/modules/devtable.iml
+++ b/.idea/modules/devtable.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="4">
   <component name="SonarLintModuleSettings">
-    <option name="uniqueId" value="8dcaacc1-a23d-4b70-82f3-d590b959a5a4" />
+    <option name="uniqueId" value="e50f2b4e-1cd9-47ce-b2cd-c66ed42d5594" />
   </component>
 </module>

--- a/.idea/modules/devtable.main.iml
+++ b/.idea/modules/devtable.main.iml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="4">
   <component name="SonarLintModuleSettings">
-    <option name="uniqueId" value="8dcaacc1-a23d-4b70-82f3-d590b959a5a4" />
+    <option name="uniqueId" value="fa8eadad-9201-448e-b7b9-8610c97de00d" />
   </component>
 </module>

--- a/src/main/java/com/mdh/devtable/waiting/ShopWaiting.java
+++ b/src/main/java/com/mdh/devtable/waiting/ShopWaiting.java
@@ -1,0 +1,56 @@
+package com.mdh.devtable.waiting;
+
+import com.mdh.devtable.global.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "shop_waitings")
+@Entity
+public class ShopWaiting extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "shop_id", nullable = false)
+    private Long shopId;
+
+    @Column(name = "status", length = 31, nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ShopWaitingStatus shopWaitingStatus;
+
+    @Column(name = "maximum", nullable = false)
+    private int maximumWaiting;
+
+    @Builder
+    public ShopWaiting(Long shopId, int maximumWaiting) {
+        validMaximumWaiting(maximumWaiting);
+        this.shopId = shopId;
+        this.maximumWaiting = maximumWaiting;
+        this.shopWaitingStatus = ShopWaitingStatus.CLOSE;
+    }
+
+    public void changeShopWaitingStatus(ShopWaitingStatus shopWaitingStatus) {
+        if (this.shopWaitingStatus == shopWaitingStatus) {
+            throw new IllegalStateException("매장의 웨이팅 상태를 동일한 상태로 변경 할 수 없습니다.");
+        }
+
+        this.shopWaitingStatus = shopWaitingStatus;
+    }
+
+    public void updateShopWaiting(int maximumWaiting) {
+        validMaximumWaiting(maximumWaiting);
+        this.maximumWaiting = maximumWaiting;
+    }
+
+    private void validMaximumWaiting(int maximumWaiting) {
+        if (maximumWaiting < 1) {
+            throw new IllegalArgumentException("웨이팅의 최대 인원수는 1 미만 일 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/com/mdh/devtable/waiting/ShopWaitingStatus.java
+++ b/src/main/java/com/mdh/devtable/waiting/ShopWaitingStatus.java
@@ -1,0 +1,12 @@
+package com.mdh.devtable.waiting;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum ShopWaitingStatus {
+    OPEN("영업 중"),
+    BREAK_TIME("브레이크 타임"),
+    CLOSE("영업 종료");
+
+    private final String statusMessage;
+}

--- a/src/test/java/com/mdh/devtable/waiting/ShopWaitingTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/ShopWaitingTest.java
@@ -1,0 +1,129 @@
+package com.mdh.devtable.waiting;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ShopWaitingTest {
+
+    @Test
+    @DisplayName("매장의 웨이팅 정보를 생성 할 수 있다.")
+    void createShopWaitingTest() {
+        //given
+        Long shopId = 1L;
+        int maximumWaiting = 10;
+
+        //when
+        var shopWaiting = ShopWaiting
+                .builder()
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
+
+        //then
+        assertThat(shopWaiting.getShopId()).isEqualTo(shopId);
+        assertThat(shopWaiting.getShopWaitingStatus()).isEqualTo(ShopWaitingStatus.CLOSE);
+        assertThat(shopWaiting.getMaximumWaiting()).isEqualTo(maximumWaiting);
+    }
+
+    @Test
+    @DisplayName("매장의 웨이팅 정보를 생성 시 최대 허용 인원수가 1 미만이면 안된다.")
+    void createShopWaitingExTest() {
+        //given
+        Long shopId = 1L;
+        int maximumWaiting = 0;
+
+        //when & then
+        assertThatThrownBy(() -> ShopWaiting.builder()
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("웨이팅의 최대 인원수는 1 미만 일 수 없습니다.");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ShopWaitingStatus.class, mode = EnumSource.Mode.EXCLUDE, names = {"CLOSE"})
+    @DisplayName("매장의 웨이팅 상태를 다른 상태로 업데이트 할 수 있다.")
+    void updateShopWaitingStatusTest(ShopWaitingStatus shopWaitingStatus) {
+        //given
+        Long shopId = 1L;
+        int maximumWaiting = 10;
+
+        var shopWaiting = ShopWaiting
+                .builder()
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
+
+        //when
+        shopWaiting.changeShopWaitingStatus(shopWaitingStatus);
+
+        //then
+        assertThat(shopWaiting.getShopWaitingStatus()).isEqualTo(shopWaitingStatus);
+    }
+
+    @Test
+    @DisplayName("매장의 웨이팅 상태를 같은 상태로 업데이트 할 수 없다.")
+    void updateShopWaitingStatusExTest() {
+        //given
+        Long shopId = 1L;
+        int maximumWaiting = 10;
+
+        var shopWaiting = ShopWaiting
+                .builder()
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
+
+        //when & then
+        assertThatThrownBy(() -> shopWaiting.changeShopWaitingStatus(shopWaiting.getShopWaitingStatus()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("매장의 웨이팅 상태를 동일한 상태로 변경 할 수 없습니다.");
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, Integer.MAX_VALUE})
+    @DisplayName("매장의 웨이팅 허용 인원 수를 설정 할 수 있다.")
+    void updateShopWaitingMaximumTest(int changeMaximumWaiting) {
+        //given
+        Long shopId = 1L;
+        int maximumWaiting = 10;
+
+        var shopWaiting = ShopWaiting
+                .builder()
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
+
+        //when
+        shopWaiting.updateShopWaiting(changeMaximumWaiting);
+
+        //then
+        assertThat(shopWaiting.getMaximumWaiting()).isEqualTo(changeMaximumWaiting);
+    }
+
+    @Test
+    @DisplayName("매장의 웨이팅 허용 인원 수를 1 미만으로 설정 할 수 없다.")
+    void updateShopWaitingMaximumExTest() {
+        //given
+        Long shopId = 1L;
+        int maximumWaiting = 10;
+
+        var shopWaiting = ShopWaiting
+                .builder()
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
+
+        //when & then
+        assertThatThrownBy(() -> shopWaiting.updateShopWaiting(0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("웨이팅의 최대 인원수는 1 미만 일 수 없습니다.");
+    }
+}

--- a/src/test/java/com/mdh/devtable/waiting/ShopWaitingTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/ShopWaitingTest.java
@@ -15,8 +15,8 @@ class ShopWaitingTest {
     @DisplayName("매장의 웨이팅 정보를 생성 할 수 있다.")
     void createShopWaitingTest() {
         //given
-        Long shopId = 1L;
-        int maximumWaiting = 10;
+        var shopId = 1L;
+        var maximumWaiting = 10;
 
         //when
         var shopWaiting = ShopWaiting
@@ -35,8 +35,8 @@ class ShopWaitingTest {
     @DisplayName("매장의 웨이팅 정보를 생성 시 최대 허용 인원수가 1 미만이면 안된다.")
     void createShopWaitingExTest() {
         //given
-        Long shopId = 1L;
-        int maximumWaiting = 0;
+        var shopId = 1L;
+        var maximumWaiting = 0;
 
         //when & then
         assertThatThrownBy(() -> ShopWaiting.builder()
@@ -52,8 +52,8 @@ class ShopWaitingTest {
     @DisplayName("매장의 웨이팅 상태를 다른 상태로 업데이트 할 수 있다.")
     void updateShopWaitingStatusTest(ShopWaitingStatus shopWaitingStatus) {
         //given
-        Long shopId = 1L;
-        int maximumWaiting = 10;
+        var shopId = 1L;
+        var maximumWaiting = 10;
 
         var shopWaiting = ShopWaiting
                 .builder()
@@ -72,8 +72,8 @@ class ShopWaitingTest {
     @DisplayName("매장의 웨이팅 상태를 같은 상태로 업데이트 할 수 없다.")
     void updateShopWaitingStatusExTest() {
         //given
-        Long shopId = 1L;
-        int maximumWaiting = 10;
+        var shopId = 1L;
+        var maximumWaiting = 10;
 
         var shopWaiting = ShopWaiting
                 .builder()
@@ -92,8 +92,8 @@ class ShopWaitingTest {
     @DisplayName("매장의 웨이팅 허용 인원 수를 설정 할 수 있다.")
     void updateShopWaitingMaximumTest(int changeMaximumWaiting) {
         //given
-        Long shopId = 1L;
-        int maximumWaiting = 10;
+        var shopId = 1L;
+        var maximumWaiting = 10;
 
         var shopWaiting = ShopWaiting
                 .builder()
@@ -112,8 +112,8 @@ class ShopWaitingTest {
     @DisplayName("매장의 웨이팅 허용 인원 수를 1 미만으로 설정 할 수 없다.")
     void updateShopWaitingMaximumExTest() {
         //given
-        Long shopId = 1L;
-        int maximumWaiting = 10;
+        var shopId = 1L;
+        var maximumWaiting = 10;
 
         var shopWaiting = ShopWaiting
                 .builder()


### PR DESCRIPTION
## 🖊️ 1. Changes
- 매장 웨이팅 엔티티를 구현하였습니다.
- 매장 웨이팅 엔티티에 대한 도메인 테스트를 진행하였습니다.
- 매장 웨이팅 생성자에서 필드 검증 로직을 적용하였습니다.

## 🖼️ 2. Screenshot
<img width="430" alt="image" src="https://github.com/prgrms-be-devcourse/BE-04-DevTable/assets/74203371/78bdabd2-811e-4a5a-ba6c-8fefa7d16adb">

## ❗️ 3. Issues

1. 테스트 코드에 타입을 명시한 부분이 있어 var로 변경하였습니다.
2. 

## 😌 4. To Reviewer

-

## ✅ 5. Plans
- [ ] - 
- [ ] - 
