### PR TITLE
[MDH-5] 웨이팅 엔티티 작성 및 테스트

### DIFF
--- a/src/main/java/com/mdh/devtable/waiting/Waiting.java
+++ b/src/main/java/com/mdh/devtable/waiting/Waiting.java
@@ -1,0 +1,52 @@
+package com.mdh.devtable.waiting;
+
+import com.mdh.devtable.global.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@Table(name = "waiting")
+@Entity
+public class Waiting extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "waiting_status", length = 31, nullable = false)
+    private WaitingStatus waitingStatus;
+
+    @Column(name = "postponed_count", nullable = false)
+    private int postponedCount;
+
+    public Waiting() {
+        this.waitingStatus = WaitingStatus.PROGRESS;
+        this.postponedCount = 0;
+    }
+
+
+    // 비즈니스 메서드
+    public void addPostponedCount() {
+        if (!isProgress()) {
+            throw new IllegalStateException("진행 상태가 아닌 웨이팅 미루기는 불가능 합니다.");
+        }
+
+        if (postponedCount >= 2) {
+            throw new IllegalStateException("웨이팅 미루기는 2회 초과하여 불가능 합니다.");
+        }
+        postponedCount++;
+    }
+
+    private boolean isProgress() {
+        return this.waitingStatus == WaitingStatus.PROGRESS;
+    }
+
+    public void changeWaitingStatus(WaitingStatus waitingStatus) {
+        if (!isProgress()) {
+            throw new IllegalStateException("진행 상태가 아니면 상태 변경이 불가능 합니다.");
+        }
+        this.waitingStatus = waitingStatus;
+    }
+}
+

--- a/src/main/java/com/mdh/devtable/waiting/Waiting.java
+++ b/src/main/java/com/mdh/devtable/waiting/Waiting.java
@@ -2,16 +2,23 @@ package com.mdh.devtable.waiting;
 
 import com.mdh.devtable.global.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Table(name = "waiting")
+@Table(name = "waitings")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Waiting extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(name = "user_id")
+    private Long userId;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "waiting_status", length = 31, nullable = false)
@@ -20,7 +27,9 @@ public class Waiting extends BaseTimeEntity {
     @Column(name = "postponed_count", nullable = false)
     private int postponedCount;
 
-    public Waiting() {
+    @Builder
+    public Waiting(Long userId) {
+        this.userId = userId;
         this.waitingStatus = WaitingStatus.PROGRESS;
         this.postponedCount = 0;
     }

--- a/src/main/java/com/mdh/devtable/waiting/WaitingStatus.java
+++ b/src/main/java/com/mdh/devtable/waiting/WaitingStatus.java
@@ -1,0 +1,6 @@
+package com.mdh.devtable.waiting;
+
+public enum WaitingStatus {
+
+    PROGRESS, CANCEL, NO_SHOW, VISITED
+}

--- a/src/test/java/com/mdh/devtable/waiting/WaitingTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/WaitingTest.java
@@ -15,7 +15,7 @@ class WaitingTest {
     @DisplayName("Waiting을 생성하면 웨이팅 상태가 PROGRESS이고, 미루기 횟수는 0이여야 한다.")
     public void waitingConstructorTest() {
         //given
-        var waiting = new Waiting();
+        var waiting = new Waiting(0L);
 
         //when
 
@@ -28,7 +28,7 @@ class WaitingTest {
     @DisplayName("Waiting의 상태가 Progress이면 미루기 횟수를 증가 시킬 수 있다.")
     public void addWaitingPostponeCountTest() {
         //given
-        var waiting = new Waiting();
+        var waiting = new Waiting(0L);
 
         //when
         waiting.addPostponedCount();
@@ -43,7 +43,7 @@ class WaitingTest {
     @DisplayName("Waiting의 상태가 Progress가 아니면 미루기 횟수를 증가 시킬 수 없다.")
     public void addWaitingPostponeCountStatusExTest(WaitingStatus waitingStatus) {
         //given
-        var waiting = new Waiting();
+        var waiting = new Waiting(0L);
 
         //when
         waiting.changeWaitingStatus(waitingStatus);
@@ -58,7 +58,7 @@ class WaitingTest {
     @DisplayName("Waiting의 미루기 횟수가 2회 일 때, 미루기 횟수를 증가시키면 예외가 발생한다.")
     public void addWaitingPostponeCountExTest() {
         //given
-        var waiting = new Waiting();
+        var waiting = new Waiting(0L);
 
         //when
         waiting.addPostponedCount();
@@ -75,7 +75,7 @@ class WaitingTest {
     @DisplayName("Waiting의 상태가 PROGRESS라면 다른 상태로 변경이 가능하다.")
     public void changeWaitingStatusTest(WaitingStatus waitingStatus) {
         //given
-        var waiting = new Waiting();
+        var waiting = new Waiting(0L);
 
         //when
         waiting.changeWaitingStatus(waitingStatus);
@@ -89,7 +89,7 @@ class WaitingTest {
     @DisplayName("Waiting의 상태가 PROGRESS가 아니라면 다른 상태로 변경이 불가능하다.")
     public void changeWaitingStatusExTest(WaitingStatus waitingStatus) {
         //given
-        var waiting = new Waiting();
+        var waiting = new Waiting(0L);
 
         //when
         waiting.changeWaitingStatus(waitingStatus);

--- a/src/test/java/com/mdh/devtable/waiting/WaitingTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/WaitingTest.java
@@ -1,0 +1,102 @@
+package com.mdh.devtable.waiting;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class WaitingTest {
+
+    @Test
+    @DisplayName("Waiting을 생성하면 웨이팅 상태가 PROGRESS이고, 미루기 횟수는 0이여야 한다.")
+    public void waitingConstructorTest() {
+        //given
+        var waiting = new Waiting();
+
+        //when
+
+        //then
+        assertThat(waiting.getPostponedCount()).isEqualTo(0);
+        assertThat(waiting.getWaitingStatus()).isEqualTo(WaitingStatus.PROGRESS);
+    }
+
+    @Test
+    @DisplayName("Waiting의 상태가 Progress이면 미루기 횟수를 증가 시킬 수 있다.")
+    public void addWaitingPostponeCountTest() {
+        //given
+        var waiting = new Waiting();
+
+        //when
+        waiting.addPostponedCount();
+
+        //then
+        assertThat(waiting.getWaitingStatus()).isEqualTo(WaitingStatus.PROGRESS);
+        assertThat(waiting.getPostponedCount()).isEqualTo(1);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = WaitingStatus.class, mode = EnumSource.Mode.EXCLUDE, names = {"PROGRESS"})
+    @DisplayName("Waiting의 상태가 Progress가 아니면 미루기 횟수를 증가 시킬 수 없다.")
+    public void addWaitingPostponeCountStatusExTest(WaitingStatus waitingStatus) {
+        //given
+        var waiting = new Waiting();
+
+        //when
+        waiting.changeWaitingStatus(waitingStatus);
+
+        //then
+        Assertions.assertThatThrownBy(waiting::addPostponedCount)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("진행 상태가 아닌 웨이팅 미루기는 불가능 합니다.");
+    }
+
+    @Test
+    @DisplayName("Waiting의 미루기 횟수가 2회 일 때, 미루기 횟수를 증가시키면 예외가 발생한다.")
+    public void addWaitingPostponeCountExTest() {
+        //given
+        var waiting = new Waiting();
+
+        //when
+        waiting.addPostponedCount();
+        waiting.addPostponedCount();
+
+        //then
+        Assertions.assertThatThrownBy(waiting::addPostponedCount)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("웨이팅 미루기는 2회 초과하여 불가능 합니다.");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = WaitingStatus.class, mode = EnumSource.Mode.EXCLUDE, names = {"PROGRESS"})
+    @DisplayName("Waiting의 상태가 PROGRESS라면 다른 상태로 변경이 가능하다.")
+    public void changeWaitingStatusTest(WaitingStatus waitingStatus) {
+        //given
+        var waiting = new Waiting();
+
+        //when
+        waiting.changeWaitingStatus(waitingStatus);
+
+        //then
+        assertThat(waiting.getWaitingStatus()).isEqualTo(waitingStatus);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = WaitingStatus.class, mode = EnumSource.Mode.EXCLUDE, names = {"PROGRESS"})
+    @DisplayName("Waiting의 상태가 PROGRESS가 아니라면 다른 상태로 변경이 불가능하다.")
+    public void changeWaitingStatusExTest(WaitingStatus waitingStatus) {
+        //given
+        var waiting = new Waiting();
+
+        //when
+        waiting.changeWaitingStatus(waitingStatus);
+
+        //then
+        assertThatThrownBy(() -> waiting.changeWaitingStatus(WaitingStatus.PROGRESS))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("진행 상태가 아니면 상태 변경이 불가능 합니다.");
+    }
+}


### PR DESCRIPTION
## 🖊️ 1. Changes
1️⃣ 웨이팅 엔티티를 작성하였습니다.
2️⃣ 웨이팅 엔티티의 비즈니스 로직을 생성하고, 이에 대한 테스트를 진행하였습니다.

## 🖼️ 2. Screenshot
<img width="542" alt="image" src="https://github.com/prgrms-be-devcourse/BE-04-DevTable/assets/74203371/b7b12b69-88fb-47a0-a710-9dffa9287a88">


## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer
- Test에 추가되어야 할 것이 있다면 확인 부탁드립니다.
- Plan이 전부 해결되면 그때 merge 하도록 하겠습니다.

## ✅ 5. Plans
- [x] - 유저 엔티티가 완성되면 유저와 연결관계를 맺을 예정입니다.
- [ ] - 매장 웨이팅 엔티티가 완성되면 연결관계를 맺을 예정입니다. 
