### PR TITLE
[MDH-5] waiting 엔티티 작성 및 테스트

### DIFF
--- a/src/main/java/com/mdh/devtable/waiting/ShopWaiting.java
+++ b/src/main/java/com/mdh/devtable/waiting/ShopWaiting.java
@@ -45,6 +45,10 @@ public class ShopWaiting extends BaseTimeEntity {
         this.maximumWaiting = maximumWaiting;
     }
 
+    public boolean isOpenWaitingStatus() {
+        return this.shopWaitingStatus == ShopWaitingStatus.OPEN;
+    }
+
     private void validMaximumWaiting(int maximumWaiting) {
         if (maximumWaiting < 1) {
             throw new IllegalArgumentException("웨이팅의 최대 인원수는 1 미만 일 수 없습니다.");

--- a/src/main/java/com/mdh/devtable/waiting/ShopWaiting.java
+++ b/src/main/java/com/mdh/devtable/waiting/ShopWaiting.java
@@ -1,7 +1,12 @@
 package com.mdh.devtable.waiting;
 
 import com.mdh.devtable.global.BaseTimeEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,15 +26,41 @@ public class ShopWaiting extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private ShopWaitingStatus shopWaitingStatus;
 
-    @Column(name = "maximum", nullable = false)
+    @Column(name = "maximum", nullable = false) // 최대 웨이팅 팀 수
     private int maximumWaiting;
 
+    @Column(name = "child_enabled", nullable = false)
+    private boolean childEnabled;
+    // 최소 웨이팅 인원, 최대 웨이팅 인원
+    @Column(name = "minimum_people", nullable = false)
+    private int minimumWaitingPeople;
+
+    @Column(name = "maximum_people", nullable = false)
+    private int maximumWaitingPeople;
+
     @Builder
-    public ShopWaiting(Long shopId, int maximumWaiting) {
+    public ShopWaiting(Long shopId,
+                       int maximumWaiting,
+                       int minimumWaitingPeople,
+                       int maximumWaitingPeople) {
         validMaximumWaiting(maximumWaiting);
         this.shopId = shopId;
         this.maximumWaiting = maximumWaiting;
         this.shopWaitingStatus = ShopWaitingStatus.CLOSE;
+        this.childEnabled = false;
+        this.minimumWaitingPeople = minimumWaitingPeople;
+        this.maximumWaitingPeople = maximumWaitingPeople;
+    }
+
+    private void validMaximumWaiting(int maximumWaiting) {
+        if (maximumWaiting < 1) {
+            throw new IllegalArgumentException("웨이팅의 최대 인원수는 1 미만 일 수 없습니다.");
+        }
+    }
+
+    public void updateShopWaiting(int maximumWaiting) {
+        validMaximumWaiting(maximumWaiting);
+        this.maximumWaiting = maximumWaiting;
     }
 
     public void changeShopWaitingStatus(ShopWaitingStatus shopWaitingStatus) {
@@ -40,18 +71,23 @@ public class ShopWaiting extends BaseTimeEntity {
         this.shopWaitingStatus = shopWaitingStatus;
     }
 
-    public void updateShopWaiting(int maximumWaiting) {
-        validMaximumWaiting(maximumWaiting);
-        this.maximumWaiting = maximumWaiting;
-    }
-
     public boolean isOpenWaitingStatus() {
         return this.shopWaitingStatus == ShopWaitingStatus.OPEN;
     }
 
-    private void validMaximumWaiting(int maximumWaiting) {
-        if (maximumWaiting < 1) {
-            throw new IllegalArgumentException("웨이팅의 최대 인원수는 1 미만 일 수 없습니다.");
+    public void updateChildEnabled(boolean childEnabled) {
+        this.childEnabled = childEnabled;
+    }
+
+    public void validOverMinimumPeople(int people) {
+        if (people < minimumWaitingPeople) {
+            throw new IllegalArgumentException("웨이팅 인원은 " + minimumWaitingPeople + "명 이상이어야 합니다.");
+        }
+    }
+
+    public void validUnderMaximumPeople(int people) {
+        if (people > maximumWaitingPeople) {
+            throw new IllegalArgumentException("웨이팅 인원은 " + maximumWaitingPeople + "명 이하여야 합니다.");
         }
     }
 }

--- a/src/main/java/com/mdh/devtable/waiting/Waiting.java
+++ b/src/main/java/com/mdh/devtable/waiting/Waiting.java
@@ -17,6 +17,10 @@ public class Waiting extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @ManyToOne
+    @JoinColumn(name = "shop_id", referencedColumnName = "id")
+    private ShopWaiting shopWaiting;
+
     @Column(name = "user_id")
     private Long userId;
 
@@ -28,12 +32,15 @@ public class Waiting extends BaseTimeEntity {
     private int postponedCount;
 
     @Builder
-    public Waiting(Long userId) {
+    public Waiting(ShopWaiting shopWaiting, Long userId) {
+        if (!shopWaiting.isOpenWaitingStatus()) {
+            throw new IllegalStateException("매장이 오픈 상태가 아니면 웨이팅을 등록 할 수 없습니다.");
+        }
+        this.shopWaiting = shopWaiting;
         this.userId = userId;
         this.waitingStatus = WaitingStatus.PROGRESS;
         this.postponedCount = 0;
     }
-
 
     // 비즈니스 메서드
     public void addPostponedCount() {

--- a/src/main/java/com/mdh/devtable/waiting/Waiting.java
+++ b/src/main/java/com/mdh/devtable/waiting/Waiting.java
@@ -1,0 +1,52 @@
+package com.mdh.devtable.waiting;
+
+import com.mdh.devtable.global.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@Table(name = "waiting")
+@Entity
+public class Waiting extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "waiting_status", length = 31, nullable = false)
+    private WaitingStatus waitingStatus;
+
+    @Column(name = "postponed_count", nullable = false)
+    private int postponedCount;
+
+    public Waiting() {
+        this.waitingStatus = WaitingStatus.PROGRESS;
+        this.postponedCount = 0;
+    }
+
+
+    // 비즈니스 메서드
+    public void addPostponedCount() {
+        if (!isProgress()) {
+            throw new IllegalStateException("진행 상태가 아닌 웨이팅 미루기는 불가능 합니다.");
+        }
+
+        if (postponedCount >= 2) {
+            throw new IllegalStateException("웨이팅 미루기는 2회 초과하여 불가능 합니다.");
+        }
+        postponedCount++;
+    }
+
+    private boolean isProgress() {
+        return this.waitingStatus == WaitingStatus.PROGRESS;
+    }
+
+    public void changeWaitingStatus(WaitingStatus waitingStatus) {
+        if (!isProgress()) {
+            throw new IllegalStateException("진행 상태가 아니면 상태 변경이 불가능 합니다.");
+        }
+        this.waitingStatus = waitingStatus;
+    }
+}
+

--- a/src/main/java/com/mdh/devtable/waiting/Waiting.java
+++ b/src/main/java/com/mdh/devtable/waiting/Waiting.java
@@ -2,16 +2,23 @@ package com.mdh.devtable.waiting;
 
 import com.mdh.devtable.global.BaseTimeEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Table(name = "waiting")
+@Table(name = "waitings")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Waiting extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(name = "user_id")
+    private Long userId;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "waiting_status", length = 31, nullable = false)
@@ -20,7 +27,9 @@ public class Waiting extends BaseTimeEntity {
     @Column(name = "postponed_count", nullable = false)
     private int postponedCount;
 
-    public Waiting() {
+    @Builder
+    public Waiting(Long userId) {
+        this.userId = userId;
         this.waitingStatus = WaitingStatus.PROGRESS;
         this.postponedCount = 0;
     }

--- a/src/main/java/com/mdh/devtable/waiting/WaitingPeople.java
+++ b/src/main/java/com/mdh/devtable/waiting/WaitingPeople.java
@@ -1,0 +1,25 @@
+package com.mdh.devtable.waiting;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class WaitingPeople {
+
+    @Column(name = "adult_count")
+    private int adultCount;
+
+    @Column(name = "child_count")
+    private int childCount;
+
+    public int totalPeople() {
+        return adultCount + childCount;
+    }
+}

--- a/src/main/java/com/mdh/devtable/waiting/WaitingStatus.java
+++ b/src/main/java/com/mdh/devtable/waiting/WaitingStatus.java
@@ -1,0 +1,6 @@
+package com.mdh.devtable.waiting;
+
+public enum WaitingStatus {
+
+    PROGRESS, CANCEL, NO_SHOW, VISITED
+}

--- a/src/test/java/com/mdh/devtable/waiting/ShopWaitingTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/ShopWaitingTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ShopWaitingTest {
 
@@ -20,10 +21,12 @@ class ShopWaitingTest {
 
         //when
         var shopWaiting = ShopWaiting
-                .builder()
-                .shopId(shopId)
-                .maximumWaiting(maximumWaiting)
-                .build();
+            .builder()
+            .shopId(shopId)
+            .maximumWaitingPeople(2)
+            .minimumWaitingPeople(1)
+            .maximumWaiting(maximumWaiting)
+            .build();
 
         //then
         assertThat(shopWaiting.getShopId()).isEqualTo(shopId);
@@ -40,11 +43,11 @@ class ShopWaitingTest {
 
         //when & then
         assertThatThrownBy(() -> ShopWaiting.builder()
-                .shopId(shopId)
-                .maximumWaiting(maximumWaiting)
-                .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("웨이팅의 최대 인원수는 1 미만 일 수 없습니다.");
+            .shopId(shopId)
+            .maximumWaiting(maximumWaiting)
+            .build())
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("웨이팅의 최대 인원수는 1 미만 일 수 없습니다.");
     }
 
     @ParameterizedTest
@@ -56,10 +59,10 @@ class ShopWaitingTest {
         var maximumWaiting = 10;
 
         var shopWaiting = ShopWaiting
-                .builder()
-                .shopId(shopId)
-                .maximumWaiting(maximumWaiting)
-                .build();
+            .builder()
+            .shopId(shopId)
+            .maximumWaiting(maximumWaiting)
+            .build();
 
         //when
         shopWaiting.changeShopWaitingStatus(shopWaitingStatus);
@@ -76,15 +79,15 @@ class ShopWaitingTest {
         var maximumWaiting = 10;
 
         var shopWaiting = ShopWaiting
-                .builder()
-                .shopId(shopId)
-                .maximumWaiting(maximumWaiting)
-                .build();
+            .builder()
+            .shopId(shopId)
+            .maximumWaiting(maximumWaiting)
+            .build();
 
         //when & then
         assertThatThrownBy(() -> shopWaiting.changeShopWaitingStatus(shopWaiting.getShopWaitingStatus()))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("매장의 웨이팅 상태를 동일한 상태로 변경 할 수 없습니다.");
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("매장의 웨이팅 상태를 동일한 상태로 변경 할 수 없습니다.");
     }
 
     @ParameterizedTest
@@ -96,10 +99,10 @@ class ShopWaitingTest {
         var maximumWaiting = 10;
 
         var shopWaiting = ShopWaiting
-                .builder()
-                .shopId(shopId)
-                .maximumWaiting(maximumWaiting)
-                .build();
+            .builder()
+            .shopId(shopId)
+            .maximumWaiting(maximumWaiting)
+            .build();
 
         //when
         shopWaiting.updateShopWaiting(changeMaximumWaiting);
@@ -116,14 +119,33 @@ class ShopWaitingTest {
         var maximumWaiting = 10;
 
         var shopWaiting = ShopWaiting
-                .builder()
-                .shopId(shopId)
-                .maximumWaiting(maximumWaiting)
-                .build();
+            .builder()
+            .shopId(shopId)
+            .maximumWaiting(maximumWaiting)
+            .build();
 
         //when & then
         assertThatThrownBy(() -> shopWaiting.updateShopWaiting(0))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("웨이팅의 최대 인원수는 1 미만 일 수 없습니다.");
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("웨이팅의 최대 인원수는 1 미만 일 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("매장의 유아 가능 여부를 설정할 수 있다.")
+    void updateChildEnabled() {
+        // given
+        var shopId = 1L;
+        var maximumWaiting = 5;
+        var shopWaiting = ShopWaiting.builder()
+            .shopId(shopId)
+            .maximumWaiting(maximumWaiting)
+            .build();
+
+        // when
+        var newChildEnabled = true;
+        shopWaiting.updateChildEnabled(newChildEnabled);
+
+        // then
+        assertTrue(shopWaiting.isChildEnabled());
     }
 }

--- a/src/test/java/com/mdh/devtable/waiting/WaitingTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/WaitingTest.java
@@ -15,7 +15,7 @@ class WaitingTest {
     @DisplayName("Waiting을 생성하면 웨이팅 상태가 PROGRESS이고, 미루기 횟수는 0이여야 한다.")
     public void waitingConstructorTest() {
         //given
-        var waiting = new Waiting();
+        var waiting = new Waiting(0L);
 
         //when
 
@@ -28,7 +28,7 @@ class WaitingTest {
     @DisplayName("Waiting의 상태가 Progress이면 미루기 횟수를 증가 시킬 수 있다.")
     public void addWaitingPostponeCountTest() {
         //given
-        var waiting = new Waiting();
+        var waiting = new Waiting(0L);
 
         //when
         waiting.addPostponedCount();
@@ -43,7 +43,7 @@ class WaitingTest {
     @DisplayName("Waiting의 상태가 Progress가 아니면 미루기 횟수를 증가 시킬 수 없다.")
     public void addWaitingPostponeCountStatusExTest(WaitingStatus waitingStatus) {
         //given
-        var waiting = new Waiting();
+        var waiting = new Waiting(0L);
 
         //when
         waiting.changeWaitingStatus(waitingStatus);
@@ -58,7 +58,7 @@ class WaitingTest {
     @DisplayName("Waiting의 미루기 횟수가 2회 일 때, 미루기 횟수를 증가시키면 예외가 발생한다.")
     public void addWaitingPostponeCountExTest() {
         //given
-        var waiting = new Waiting();
+        var waiting = new Waiting(0L);
 
         //when
         waiting.addPostponedCount();
@@ -75,7 +75,7 @@ class WaitingTest {
     @DisplayName("Waiting의 상태가 PROGRESS라면 다른 상태로 변경이 가능하다.")
     public void changeWaitingStatusTest(WaitingStatus waitingStatus) {
         //given
-        var waiting = new Waiting();
+        var waiting = new Waiting(0L);
 
         //when
         waiting.changeWaitingStatus(waitingStatus);
@@ -89,7 +89,7 @@ class WaitingTest {
     @DisplayName("Waiting의 상태가 PROGRESS가 아니라면 다른 상태로 변경이 불가능하다.")
     public void changeWaitingStatusExTest(WaitingStatus waitingStatus) {
         //given
-        var waiting = new Waiting();
+        var waiting = new Waiting(0L);
 
         //when
         waiting.changeWaitingStatus(waitingStatus);

--- a/src/test/java/com/mdh/devtable/waiting/WaitingTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/WaitingTest.java
@@ -1,0 +1,102 @@
+package com.mdh.devtable.waiting;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class WaitingTest {
+
+    @Test
+    @DisplayName("Waiting을 생성하면 웨이팅 상태가 PROGRESS이고, 미루기 횟수는 0이여야 한다.")
+    public void waitingConstructorTest() {
+        //given
+        var waiting = new Waiting();
+
+        //when
+
+        //then
+        assertThat(waiting.getPostponedCount()).isEqualTo(0);
+        assertThat(waiting.getWaitingStatus()).isEqualTo(WaitingStatus.PROGRESS);
+    }
+
+    @Test
+    @DisplayName("Waiting의 상태가 Progress이면 미루기 횟수를 증가 시킬 수 있다.")
+    public void addWaitingPostponeCountTest() {
+        //given
+        var waiting = new Waiting();
+
+        //when
+        waiting.addPostponedCount();
+
+        //then
+        assertThat(waiting.getWaitingStatus()).isEqualTo(WaitingStatus.PROGRESS);
+        assertThat(waiting.getPostponedCount()).isEqualTo(1);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = WaitingStatus.class, mode = EnumSource.Mode.EXCLUDE, names = {"PROGRESS"})
+    @DisplayName("Waiting의 상태가 Progress가 아니면 미루기 횟수를 증가 시킬 수 없다.")
+    public void addWaitingPostponeCountStatusExTest(WaitingStatus waitingStatus) {
+        //given
+        var waiting = new Waiting();
+
+        //when
+        waiting.changeWaitingStatus(waitingStatus);
+
+        //then
+        Assertions.assertThatThrownBy(waiting::addPostponedCount)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("진행 상태가 아닌 웨이팅 미루기는 불가능 합니다.");
+    }
+
+    @Test
+    @DisplayName("Waiting의 미루기 횟수가 2회 일 때, 미루기 횟수를 증가시키면 예외가 발생한다.")
+    public void addWaitingPostponeCountExTest() {
+        //given
+        var waiting = new Waiting();
+
+        //when
+        waiting.addPostponedCount();
+        waiting.addPostponedCount();
+
+        //then
+        Assertions.assertThatThrownBy(waiting::addPostponedCount)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("웨이팅 미루기는 2회 초과하여 불가능 합니다.");
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = WaitingStatus.class, mode = EnumSource.Mode.EXCLUDE, names = {"PROGRESS"})
+    @DisplayName("Waiting의 상태가 PROGRESS라면 다른 상태로 변경이 가능하다.")
+    public void changeWaitingStatusTest(WaitingStatus waitingStatus) {
+        //given
+        var waiting = new Waiting();
+
+        //when
+        waiting.changeWaitingStatus(waitingStatus);
+
+        //then
+        assertThat(waiting.getWaitingStatus()).isEqualTo(waitingStatus);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = WaitingStatus.class, mode = EnumSource.Mode.EXCLUDE, names = {"PROGRESS"})
+    @DisplayName("Waiting의 상태가 PROGRESS가 아니라면 다른 상태로 변경이 불가능하다.")
+    public void changeWaitingStatusExTest(WaitingStatus waitingStatus) {
+        //given
+        var waiting = new Waiting();
+
+        //when
+        waiting.changeWaitingStatus(waitingStatus);
+
+        //then
+        assertThatThrownBy(() -> waiting.changeWaitingStatus(WaitingStatus.PROGRESS))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("진행 상태가 아니면 상태 변경이 불가능 합니다.");
+    }
+}

--- a/src/test/java/com/mdh/devtable/waiting/WaitingTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/WaitingTest.java
@@ -15,21 +15,76 @@ class WaitingTest {
     @DisplayName("Waiting을 생성하면 웨이팅 상태가 PROGRESS이고, 미루기 횟수는 0이여야 한다.")
     public void waitingConstructorTest() {
         //given
-        var waiting = new Waiting(0L);
+        var shopId = 1L;
+        var maximumWaiting = 10;
+        var userId = 1L;
 
+        var shopWaiting = ShopWaiting
+                .builder()
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
+
+        shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
         //when
+        var waiting = Waiting.builder()
+                .shopWaiting(shopWaiting)
+                .userId(userId)
+                .build();
 
         //then
+        assertThat(waiting.getShopWaiting()).isEqualTo(shopWaiting);
+        assertThat(waiting.getUserId()).isEqualTo(userId);
         assertThat(waiting.getPostponedCount()).isEqualTo(0);
         assertThat(waiting.getWaitingStatus()).isEqualTo(WaitingStatus.PROGRESS);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = ShopWaitingStatus.class, mode = EnumSource.Mode.EXCLUDE, names = {"OPEN"})
+    @DisplayName("매장 상태가 OPEN이 아닐 때 Waiting을 생성하면 예외가 발생한다.")
+    public void waitingConstructorExTest(ShopWaitingStatus waitingStatus) {
+        //given
+        var shopId = 1L;
+        var maximumWaiting = 10;
+        var userId = 1L;
+
+        var shopWaiting = ShopWaiting
+                .builder()
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
+        shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
+        shopWaiting.changeShopWaitingStatus(waitingStatus);
+
+        //when & then
+        assertThatThrownBy(() -> Waiting.builder()
+                .shopWaiting(shopWaiting)
+                .userId(userId)
+                .build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("매장이 오픈 상태가 아니면 웨이팅을 등록 할 수 없습니다.");
     }
 
     @Test
     @DisplayName("Waiting의 상태가 Progress이면 미루기 횟수를 증가 시킬 수 있다.")
     public void addWaitingPostponeCountTest() {
         //given
-        var waiting = new Waiting(0L);
+        var shopId = 1L;
+        var maximumWaiting = 10;
+        var userId = 1L;
 
+        var shopWaiting = ShopWaiting
+                .builder()
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
+
+        shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
+
+        var waiting = Waiting.builder()
+                .shopWaiting(shopWaiting)
+                .userId(userId)
+                .build();
         //when
         waiting.addPostponedCount();
 
@@ -43,7 +98,22 @@ class WaitingTest {
     @DisplayName("Waiting의 상태가 Progress가 아니면 미루기 횟수를 증가 시킬 수 없다.")
     public void addWaitingPostponeCountStatusExTest(WaitingStatus waitingStatus) {
         //given
-        var waiting = new Waiting(0L);
+        var shopId = 1L;
+        var maximumWaiting = 10;
+        var userId = 1L;
+
+        var shopWaiting = ShopWaiting
+                .builder()
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
+
+        shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
+
+        var waiting = Waiting.builder()
+                .shopWaiting(shopWaiting)
+                .userId(userId)
+                .build();
 
         //when
         waiting.changeWaitingStatus(waitingStatus);
@@ -58,7 +128,22 @@ class WaitingTest {
     @DisplayName("Waiting의 미루기 횟수가 2회 일 때, 미루기 횟수를 증가시키면 예외가 발생한다.")
     public void addWaitingPostponeCountExTest() {
         //given
-        var waiting = new Waiting(0L);
+        var shopId = 1L;
+        var maximumWaiting = 10;
+        var userId = 1L;
+
+        var shopWaiting = ShopWaiting
+                .builder()
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
+
+        shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
+
+        var waiting = Waiting.builder()
+                .shopWaiting(shopWaiting)
+                .userId(userId)
+                .build();
 
         //when
         waiting.addPostponedCount();
@@ -75,7 +160,22 @@ class WaitingTest {
     @DisplayName("Waiting의 상태가 PROGRESS라면 다른 상태로 변경이 가능하다.")
     public void changeWaitingStatusTest(WaitingStatus waitingStatus) {
         //given
-        var waiting = new Waiting(0L);
+        var shopId = 1L;
+        var maximumWaiting = 10;
+        var userId = 1L;
+
+        var shopWaiting = ShopWaiting
+                .builder()
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
+
+        shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
+
+        var waiting = Waiting.builder()
+                .shopWaiting(shopWaiting)
+                .userId(userId)
+                .build();
 
         //when
         waiting.changeWaitingStatus(waitingStatus);
@@ -89,7 +189,22 @@ class WaitingTest {
     @DisplayName("Waiting의 상태가 PROGRESS가 아니라면 다른 상태로 변경이 불가능하다.")
     public void changeWaitingStatusExTest(WaitingStatus waitingStatus) {
         //given
-        var waiting = new Waiting(0L);
+        var shopId = 1L;
+        var maximumWaiting = 10;
+        var userId = 1L;
+
+        var shopWaiting = ShopWaiting
+                .builder()
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
+
+        shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
+
+        var waiting = Waiting.builder()
+                .shopWaiting(shopWaiting)
+                .userId(userId)
+                .build();
 
         //when
         waiting.changeWaitingStatus(waitingStatus);


### PR DESCRIPTION
## 🖊️ 1. Changes
1️⃣ 웨이팅 엔티티를 작성하였습니다.
2️⃣ 웨이팅 엔티티의 비즈니스 로직을 생성하고, 이에 대한 테스트를 진행하였습니다.

## 🖼️ 2. Screenshot
![waiting test](https://github.com/prgrms-be-devcourse/BE-04-DevTable/assets/83766322/49d9ec06-789f-4b3c-9bc6-3f9542435742)


## ❗️ 3. Issues

1. 웨이팅 시 웨이팅 인원에 대한 필드가 누락되었습니다. DB에도 필드를 추가하여야 합니다.
2. 웨이팅 시 웨이팅 인원에 따른 필드를 추가함에 따라, 매장 웨이팅 테이블에도 최소 인원수와 최대 인원수 필드가 추가되어야 합니다.

## 😌 4. To Reviewer
- Test에 추가되어야 할 것이 있다면 확인 부탁드립니다.
- Plan이 전부 해결되면 그때 merge 하도록 하겠습니다.

## ✅ 5. Plans
- [X] - 유저 엔티티가 완성되면 유저와 연결관계를 맺을 예정입니다.
- [x] - 매장 웨이팅 엔티티가 완성되면 연결관계를 맺을 예정입니다. 
- [x] - 매장 웨이팅의 웨이팅의 최소, 최대 인원수 필드를 추가해야 한다.
- [x] - 웨이팅 엔티티에 웨이팅 인원을 추가해야 한다.