### PR TITLE
[MDH-22] feat : 매장 웨이팅 상태변경 서비스, 테스트 코드 작성

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$" />
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK" />
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/devtable.test.iml" filepath="$PROJECT_DIR$/.idea/modules/devtable.test.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/devtable.main.iml" filepath="$PROJECT_DIR$/.idea/modules/devtable.main.iml" />
     </modules>
   </component>
 </project>

--- a/.idea/modules/devtable.main.iml
+++ b/.idea/modules/devtable.main.iml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
+    </content>
+  </component>
   <component name="SonarLintModuleSettings">
     <option name="uniqueId" value="fa8eadad-9201-448e-b7b9-8610c97de00d" />
   </component>

--- a/src/main/java/com/mdh/devtable/ownerwaitng/application/OwnerWaitingService.java
+++ b/src/main/java/com/mdh/devtable/ownerwaitng/application/OwnerWaitingService.java
@@ -1,0 +1,24 @@
+package com.mdh.devtable.ownerwaitng.application;
+
+import com.mdh.devtable.ownerwaitng.infra.persistence.OwnerWaitingRepository;
+import com.mdh.devtable.ownerwaitng.presentaion.OwnerWaitingChangeRequest;
+import com.mdh.devtable.waiting.ShopWaitingStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class OwnerWaitingService {
+
+    private final OwnerWaitingRepository ownerWaitingRepository;
+
+    @Transactional
+    public void changShopWaitingStatus(Long shopId, OwnerWaitingChangeRequest request) {
+        var shopWaiting = ownerWaitingRepository.findByShopId(shopId)
+                .orElseThrow(() -> new NoSuchElementException("매장 웨이팅 조회 결과가 없습니다."));
+        shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.valueOf(request.waitingStatus()));
+    }
+}

--- a/src/main/java/com/mdh/devtable/ownerwaitng/infra/persistence/OwnerWaitingRepository.java
+++ b/src/main/java/com/mdh/devtable/ownerwaitng/infra/persistence/OwnerWaitingRepository.java
@@ -1,0 +1,10 @@
+package com.mdh.devtable.ownerwaitng.infra.persistence;
+
+import com.mdh.devtable.waiting.ShopWaiting;
+
+import java.util.Optional;
+
+public interface OwnerWaitingRepository {
+
+    Optional<ShopWaiting> findByShopId(Long shopId);
+}

--- a/src/main/java/com/mdh/devtable/ownerwaitng/infra/persistence/OwnerWaitingRepositoryImpl.java
+++ b/src/main/java/com/mdh/devtable/ownerwaitng/infra/persistence/OwnerWaitingRepositoryImpl.java
@@ -1,0 +1,20 @@
+package com.mdh.devtable.ownerwaitng.infra.persistence;
+
+import com.mdh.devtable.waiting.ShopWaiting;
+import com.mdh.devtable.waiting.ShopWaitingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class OwnerWaitingRepositoryImpl implements OwnerWaitingRepository {
+
+    private final ShopWaitingRepository shopWaitingRepository;
+
+    @Override
+    public Optional<ShopWaiting> findByShopId(Long shopId) {
+        return shopWaitingRepository.findById(shopId);
+    }
+}

--- a/src/main/java/com/mdh/devtable/ownerwaitng/presentaion/OwnerWaitingChangeRequest.java
+++ b/src/main/java/com/mdh/devtable/ownerwaitng/presentaion/OwnerWaitingChangeRequest.java
@@ -1,0 +1,6 @@
+package com.mdh.devtable.ownerwaitng.presentaion;
+
+public record OwnerWaitingChangeRequest(
+        String waitingStatus
+) {
+}

--- a/src/main/java/com/mdh/devtable/waiting/ShopWaitingRepository.java
+++ b/src/main/java/com/mdh/devtable/waiting/ShopWaitingRepository.java
@@ -1,0 +1,6 @@
+package com.mdh.devtable.waiting;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShopWaitingRepository extends JpaRepository<ShopWaiting, Long> {
+}

--- a/src/main/java/com/mdh/devtable/waiting/Waiting.java
+++ b/src/main/java/com/mdh/devtable/waiting/Waiting.java
@@ -28,7 +28,7 @@ public class Waiting extends BaseTimeEntity {
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "shop_id", referencedColumnName = "id")
+    @JoinColumn(name = "shop_id")
     private ShopWaiting shopWaiting;
 
     @Column(name = "user_id")
@@ -95,4 +95,3 @@ public class Waiting extends BaseTimeEntity {
     }
 
 }
-

--- a/src/test/java/com/mdh/devtable/ownerwaitng/application/OwnerWaitingServiceTest.java
+++ b/src/test/java/com/mdh/devtable/ownerwaitng/application/OwnerWaitingServiceTest.java
@@ -1,0 +1,50 @@
+package com.mdh.devtable.ownerwaitng.application;
+
+import com.mdh.devtable.ownerwaitng.infra.persistence.OwnerWaitingRepository;
+import com.mdh.devtable.ownerwaitng.presentaion.OwnerWaitingChangeRequest;
+import com.mdh.devtable.waiting.ShopWaiting;
+import com.mdh.devtable.waiting.ShopWaitingRepository;
+import com.mdh.devtable.waiting.ShopWaitingStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class OwnerWaitingServiceTest {
+
+    @Autowired
+    private OwnerWaitingService ownerWaitingService;
+
+    @Autowired
+    private ShopWaitingRepository shopWaitingRepository;
+
+    @DisplayName("매장 웨이팅 상태를 변경할 수 있다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"OPEN", "BREAK_TIME"})
+    void changShopWaitingStatus(String status) {
+        //given
+        var shopWaiting = ShopWaiting
+                .builder()
+                .shopId(1L)
+                .maximumWaitingPeople(2)
+                .minimumWaitingPeople(1)
+                .maximumWaiting(10)
+                .build();
+        shopWaitingRepository.save(shopWaiting);
+
+        //when
+        var request = new OwnerWaitingChangeRequest(status);
+        ownerWaitingService.changShopWaitingStatus(shopWaiting.getShopId(), request);
+
+        //then
+        var updatedShopWaiting = shopWaitingRepository.findById(shopWaiting.getShopId()).orElseThrow();
+        assertEquals(ShopWaitingStatus.valueOf(status), updatedShopWaiting.getShopWaitingStatus());
+    }
+}


### PR DESCRIPTION
## 🖊️ 1. Changes

- 매장 예약 상태 변경 기능 넣었습니다.
- 브레이크, 오픈, 클로즈 전부 따로 두기 보다는 status를 받아서 하는 것이 나을 것 같아서 따로 분리하지 않았습니다.

## 🖼️ 2. Screenshot

- 

## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer

- Repository를 인터페이스로 만든 이유는 Owner Waiting라는 기능을 Waiting이라는 것으로 볼지, Owner 라는 것으로 볼지 고민했는데 아무래도 Owner용은 서비스가 따로 분리될 가능성이 있어서 우선 영속성 영역은 인터페이스로 추상화를 했습니다.'
- 테스트 코드에 CLOSE를 넣지 않은 이유는 동일한 매장 상태로 변경이 불가능하기 때문입니다. 예외 테스트는 이미 도메인 테스트를 할 때 해서 뺐습니다.

## ✅ 5. Plans
- [ ] - 
- [ ] - 
