### PR TITLE
[MDH-52] 유저 웨이팅 발급번호 기능 및 테스트

### DIFF
--- a/src/main/java/com/mdh/devtable/shop/Shop.java
+++ b/src/main/java/com/mdh/devtable/shop/Shop.java
@@ -1,22 +1,8 @@
 package com.mdh.devtable.shop;
 
 import com.mdh.devtable.global.BaseTimeEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
+import jakarta.persistence.*;
+import lombok.*;
 
 @Getter
 @Table(name = "shops")
@@ -27,6 +13,13 @@ public class Shop extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "region_id", referencedColumnName = "id")
+    private Region region;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
 
     @Column(name = "name", length = 63, nullable = false)
     private String name;
@@ -50,17 +43,16 @@ public class Shop extends BaseTimeEntity {
     @Embedded
     private ShopAddress shopAddress;
 
-    @ManyToOne
-    @JoinColumn(name = "region_id", referencedColumnName = "id")
-    private Region region;
-
     @Builder
-    public Shop(@NonNull String name,
-                @NonNull String description,
-                @NonNull ShopType shopType,
-                @NonNull ShopDetails shopDetails,
-                @NonNull ShopAddress shopAddress,
-                @NonNull Region region) {
+    public Shop(
+            @NonNull Long userId,
+            @NonNull String name,
+            @NonNull String description,
+            @NonNull ShopType shopType,
+            @NonNull ShopDetails shopDetails,
+            @NonNull ShopAddress shopAddress,
+            @NonNull Region region) {
+        this.userId = userId;
         this.name = name;
         this.description = description;
         this.shopType = shopType;
@@ -71,15 +63,14 @@ public class Shop extends BaseTimeEntity {
         this.region = region;
     }
 
-
     // 비즈니스 메서드
     public void update(
-        @NonNull String name,
-        @NonNull String description,
-        @NonNull ShopType shopType,
-        @NonNull ShopDetails shopDetails,
-        @NonNull ShopAddress shopAddress,
-        @NonNull Region region
+            @NonNull String name,
+            @NonNull String description,
+            @NonNull ShopType shopType,
+            @NonNull ShopDetails shopDetails,
+            @NonNull ShopAddress shopAddress,
+            @NonNull Region region
     ) {
         this.name = name;
         this.description = description;

--- a/src/main/java/com/mdh/devtable/shop/infra/persistence/RegionRepository.java
+++ b/src/main/java/com/mdh/devtable/shop/infra/persistence/RegionRepository.java
@@ -1,0 +1,7 @@
+package com.mdh.devtable.shop.infra.persistence;
+
+import com.mdh.devtable.shop.Region;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RegionRepository extends JpaRepository<Region, Long> {
+}

--- a/src/main/java/com/mdh/devtable/waiting/application/WaitingService.java
+++ b/src/main/java/com/mdh/devtable/waiting/application/WaitingService.java
@@ -19,6 +19,7 @@ public class WaitingService {
 
     private final WaitingRepository waitingRepository;
     private final ShopWaitingRepository shopWaitingRepository;
+    private final WaitingServiceValidator waitingServiceValidator;
     private final WaitingLine waitingLine;
 
     @Transactional
@@ -27,9 +28,17 @@ public class WaitingService {
         var shopWaiting = shopWaitingRepository.findById(shopId)
                 .orElseThrow(() -> new IllegalStateException("해당 매장에 웨이팅 정보가 존재하지 않습니다. shopId : " + shopId));
 
-        var waitingPeople = createWaitingPeople(waitingCreateRequest);
 
         var userId = waitingCreateRequest.userId();
+
+        if (waitingServiceValidator.isExistsWaiting(userId)) {
+            throw new IllegalStateException("해당 매장에 이미 웨이팅이 등록되어있다면 웨이팅을 추가로 등록 할 수 없다. userId : " + userId);
+
+        }
+        shopWaiting.addWaitingCount();
+
+        var waitingPeople = createWaitingPeople(waitingCreateRequest);
+
         var waiting = Waiting.builder()
                 .shopWaiting(shopWaiting)
                 .waitingPeople(waitingPeople)

--- a/src/main/java/com/mdh/devtable/waiting/application/WaitingServiceValidator.java
+++ b/src/main/java/com/mdh/devtable/waiting/application/WaitingServiceValidator.java
@@ -1,0 +1,19 @@
+package com.mdh.devtable.waiting.application;
+
+import com.mdh.devtable.waiting.infra.persistence.WaitingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Component
+public class WaitingServiceValidator {
+
+    private final WaitingRepository waitingRepository;
+
+    @Transactional(readOnly = true)
+    public boolean isExistsWaiting(Long userId) {
+        return waitingRepository.findByProgressWaiting(userId)
+                .isPresent();
+    }
+}

--- a/src/main/java/com/mdh/devtable/waiting/domain/ShopWaiting.java
+++ b/src/main/java/com/mdh/devtable/waiting/domain/ShopWaiting.java
@@ -82,6 +82,10 @@ public class ShopWaiting extends BaseTimeEntity {
     }
 
     public void addWaitingCount() {
+        if (this.shopWaitingStatus.isCloseWaitingStatus()) {
+            throw new IllegalStateException("닫혀있는 상태에서는 발급번호 개수가 증가할 수 없습니다.");
+        }
+
         this.waitingCount++;
     }
 

--- a/src/main/java/com/mdh/devtable/waiting/domain/ShopWaiting.java
+++ b/src/main/java/com/mdh/devtable/waiting/domain/ShopWaiting.java
@@ -17,6 +17,9 @@ public class ShopWaiting extends BaseTimeEntity {
     @Column(name = "shop_id", nullable = false)
     private Long shopId;
 
+    @Column(name = "waiting_count", nullable = false)
+    private int waitingCount;
+
     @Column(name = "status", length = 31, nullable = false)
     @Enumerated(EnumType.STRING)
     private ShopWaitingStatus shopWaitingStatus;
@@ -43,6 +46,7 @@ public class ShopWaiting extends BaseTimeEntity {
                        int maximumWaitingPeople) {
         validMaximumWaiting(maximumWaiting);
         this.shopId = shopId;
+        this.waitingCount = 0;
         this.maximumWaiting = maximumWaiting;
         this.shopWaitingStatus = ShopWaitingStatus.CLOSE;
         this.childEnabled = false;
@@ -66,11 +70,19 @@ public class ShopWaiting extends BaseTimeEntity {
             throw new IllegalStateException("매장의 웨이팅 상태를 동일한 상태로 변경 할 수 없습니다.");
         }
 
+        if (shopWaitingStatus.isCloseWaitingStatus()) {
+            this.waitingCount = 0;
+        }
+
         this.shopWaitingStatus = shopWaitingStatus;
     }
 
     public boolean isOpenWaitingStatus() {
         return this.shopWaitingStatus == ShopWaitingStatus.OPEN;
+    }
+
+    public void addWaitingCount() {
+        this.waitingCount++;
     }
 
     public void updateChildEnabled(boolean childEnabled) {

--- a/src/main/java/com/mdh/devtable/waiting/domain/ShopWaitingStatus.java
+++ b/src/main/java/com/mdh/devtable/waiting/domain/ShopWaitingStatus.java
@@ -9,4 +9,8 @@ public enum ShopWaitingStatus {
     CLOSE("영업 종료");
 
     private final String statusMessage;
+
+    public boolean isCloseWaitingStatus() {
+        return this == ShopWaitingStatus.CLOSE;
+    }
 }

--- a/src/main/java/com/mdh/devtable/waiting/domain/Waiting.java
+++ b/src/main/java/com/mdh/devtable/waiting/domain/Waiting.java
@@ -1,17 +1,7 @@
 package com.mdh.devtable.waiting.domain;
 
 import com.mdh.devtable.global.BaseTimeEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,6 +24,9 @@ public class Waiting extends BaseTimeEntity {
     @Column(name = "user_id")
     private Long userId;
 
+    @Column(name = "waiting_number", nullable = false)
+    private int waitingNumber;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "waiting_status", length = 31, nullable = false)
     private WaitingStatus waitingStatus;
@@ -54,6 +47,7 @@ public class Waiting extends BaseTimeEntity {
         validChildEnable(shopWaiting, waitingPeople);
         this.shopWaiting = shopWaiting;
         this.userId = userId;
+        this.waitingNumber = shopWaiting.getWaitingCount();
         this.waitingStatus = WaitingStatus.PROGRESS;
         this.postponedCount = 0;
         this.waitingPeople = waitingPeople;

--- a/src/main/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepository.java
+++ b/src/main/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepository.java
@@ -2,6 +2,13 @@ package com.mdh.devtable.waiting.infra.persistence;
 
 import com.mdh.devtable.waiting.domain.Waiting;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface WaitingRepository extends JpaRepository<Waiting, Long> {
+
+    @Query("select w from Waiting w where w.waitingStatus = 'PROGRESS' and w.userId = :userId")
+    Optional<Waiting> findByProgressWaiting(@Param("userId") Long userId);
 }

--- a/src/test/java/com/mdh/devtable/shop/ShopTest.java
+++ b/src/test/java/com/mdh/devtable/shop/ShopTest.java
@@ -14,53 +14,56 @@ class ShopTest {
     @DisplayName("Shop을 생성하면 북마크 수는 0이어야 한다")
     void shopConstructorTest() {
         // given
+        var userId = 1L;
+
         var shopDetails = ShopDetails.builder()
-            .url("www.example.com")
-            .holiday("일요일")
-            .openingHours("11시")
-            .phoneNumber("01012345678")
-            .info("정보")
-            .introduce("introduce")
-            .build();
+                .url("www.example.com")
+                .holiday("일요일")
+                .openingHours("11시")
+                .phoneNumber("01012345678")
+                .info("정보")
+                .introduce("introduce")
+                .build();
 
         var shopAddress = ShopAddress.builder()
-            .address("가로수길 31-3, 301호")
-            .zipcode("11111")
-            .latitude("123.123")
-            .longitude("123.123")
-            .build();
+                .address("가로수길 31-3, 301호")
+                .zipcode("11111")
+                .latitude("123.123")
+                .longitude("123.123")
+                .build();
 
         var region = Region.builder()
-            .city("서울시")
-            .district("강남구")
-            .build();
+                .city("서울시")
+                .district("강남구")
+                .build();
 
         // when
         Shop shop = Shop.builder()
-            .name("Test Shop")
-            .description("This is a test shop")
-            .shopType(ShopType.KOREAN) // 가정: ShopType 열거형에 TYPE1이 있음
-            .shopDetails(shopDetails)
-            .shopAddress(shopAddress)
-            .region(region)
-            .build();
+                .userId(userId)
+                .name("Test Shop")
+                .description("This is a test shop")
+                .shopType(ShopType.KOREAN) // 가정: ShopType 열거형에 TYPE1이 있음
+                .shopDetails(shopDetails)
+                .shopAddress(shopAddress)
+                .region(region)
+                .build();
 
         // then
         assertThat(shop)
-            .extracting(Shop::getBookmarkCount,
-                Shop::getName,
-                Shop::getDescription,
-                Shop::getShopType,
-                Shop::getShopDetails,
-                Shop::getShopAddress,
-                Shop::getRegion)
-            .containsExactly(0,
-                "Test Shop",
-                "This is a test shop",
-                ShopType.KOREAN,
-                shopDetails,
-                shopAddress,
-                region);
+                .extracting(Shop::getBookmarkCount,
+                        Shop::getName,
+                        Shop::getDescription,
+                        Shop::getShopType,
+                        Shop::getShopDetails,
+                        Shop::getShopAddress,
+                        Shop::getRegion)
+                .containsExactly(0,
+                        "Test Shop",
+                        "This is a test shop",
+                        ShopType.KOREAN,
+                        shopDetails,
+                        shopAddress,
+                        region);
     }
 
     @Disabled
@@ -75,85 +78,88 @@ class ShopTest {
     @DisplayName("Shop의 정보를 수정한다.")
     void updateShopInfo() {
         // given
+        var userId = 1L;
+
         var shopDetails = ShopDetails.builder()
-            .url("www.example.com")
-            .holiday("일요일")
-            .openingHours("11시")
-            .phoneNumber("01012345678")
-            .info("정보")
-            .introduce("introduce")
-            .build();
+                .url("www.example.com")
+                .holiday("일요일")
+                .openingHours("11시")
+                .phoneNumber("01012345678")
+                .info("정보")
+                .introduce("introduce")
+                .build();
 
         var shopAddress = ShopAddress.builder()
-            .address("잠실로 62, 302동 202호")
-            .zipcode("11111")
-            .latitude("123.123")
-            .longitude("123.123")
-            .build();
+                .address("잠실로 62, 302동 202호")
+                .zipcode("11111")
+                .latitude("123.123")
+                .longitude("123.123")
+                .build();
 
         var region = Region.builder()
-            .city("서울시")
-            .district("강남구")
-            .build();
+                .city("서울시")
+                .district("강남구")
+                .build();
 
         Shop shop = Shop.builder()
-            .name("Test Shop")
-            .description("This is a test shop")
-            .shopType(ShopType.KOREAN) // 가정: ShopType 열거형에 TYPE1이 있음
-            .shopDetails(shopDetails)
-            .shopAddress(shopAddress)
-            .region(region)
-            .build();
+                .userId(1L)
+                .name("Test Shop")
+                .description("This is a test shop")
+                .shopType(ShopType.KOREAN) // 가정: ShopType 열거형에 TYPE1이 있음
+                .shopDetails(shopDetails)
+                .shopAddress(shopAddress)
+                .region(region)
+                .build();
 
         String changeName = "changedName";
         String changeDescription = "changedDescription";
         ShopType changeShopType = ShopType.ASIAN;
 
         var changeShopDetails = ShopDetails.builder()
-            .url("www.change.com")
-            .holiday("일요일")
-            .openingHours("12시")
-            .phoneNumber("01012345678")
-            .info("정보")
-            .introduce("introduce")
-            .build();
+                .url("www.change.com")
+                .holiday("일요일")
+                .openingHours("12시")
+                .phoneNumber("01012345678")
+                .info("정보")
+                .introduce("introduce")
+                .build();
 
         var changeShopAddress = ShopAddress.builder()
-            .address("서울시 송파구")
-            .zipcode("12345")
-            .latitude("123.345")
-            .longitude("123.127")
-            .build();
+                .address("서울시 송파구")
+                .zipcode("12345")
+                .latitude("123.345")
+                .longitude("123.127")
+                .build();
 
         var changeRegion = Region.builder()
-            .city("서울")
-            .district("송파구")
-            .build();
+                .city("서울")
+                .district("송파구")
+                .build();
 
         // when
         shop.update(changeName,
-            changeDescription,
-            changeShopType,
-            changeShopDetails,
-            changeShopAddress,
-            changeRegion);
-
-        // then
-        assertThat(shop)
-            .extracting(Shop::getBookmarkCount,
-                Shop::getName,
-                Shop::getDescription,
-                Shop::getShopType,
-                Shop::getShopDetails,
-                Shop::getShopAddress,
-                Shop::getRegion)
-            .containsExactly(0,
-                changeName,
                 changeDescription,
                 changeShopType,
                 changeShopDetails,
                 changeShopAddress,
                 changeRegion);
+
+        // then
+        assertThat(shop)
+                .extracting(Shop::getBookmarkCount,
+                        Shop::getName,
+                        Shop::getDescription,
+                        Shop::getShopType,
+                        Shop::getShopDetails,
+                        Shop::getShopAddress,
+                        Shop::getRegion)
+                .containsExactly(0,
+                        changeName,
+                        changeDescription,
+                        changeShopType,
+                        changeShopDetails,
+                        changeShopAddress,
+                        changeRegion);
     }
 
     @Disabled
@@ -169,35 +175,38 @@ class ShopTest {
     @DisplayName("북마크 개수를 증가시킨다.")
     void increaseBookMarks() {
         // given
+        var userId = 1L;
+
         var shopDetails = ShopDetails.builder()
-            .url("www.example.com")
-            .holiday("일요일")
-            .openingHours("11시")
-            .phoneNumber("01012345678")
-            .info("정보")
-            .introduce("introduce")
-            .build();
+                .url("www.example.com")
+                .holiday("일요일")
+                .openingHours("11시")
+                .phoneNumber("01012345678")
+                .info("정보")
+                .introduce("introduce")
+                .build();
 
         var shopAddress = ShopAddress.builder()
-            .address("서울시 강남구")
-            .zipcode("11111")
-            .latitude("123.123")
-            .longitude("123.123")
-            .build();
+                .address("서울시 강남구")
+                .zipcode("11111")
+                .latitude("123.123")
+                .longitude("123.123")
+                .build();
 
         var region = Region.builder()
-            .city("서울시")
-            .district("강남구")
-            .build();
+                .city("서울시")
+                .district("강남구")
+                .build();
 
         Shop shop = Shop.builder()
-            .name("Test Shop")
-            .description("This is a test shop")
-            .shopType(ShopType.KOREAN)
-            .shopDetails(shopDetails)
-            .shopAddress(shopAddress)
-            .region(region)
-            .build();
+                .userId(1L)
+                .name("Test Shop")
+                .description("This is a test shop")
+                .shopType(ShopType.KOREAN)
+                .shopDetails(shopDetails)
+                .shopAddress(shopAddress)
+                .region(region)
+                .build();
 
         // when
         shop.increaseBookmarkCount();
@@ -210,35 +219,38 @@ class ShopTest {
     @DisplayName("북마크 개수를 감소시킨다.")
     void decreaseBookMarks() {
         // given
+        var userId = 1L;
+
         var shopDetails = ShopDetails.builder()
-            .url("www.example.com")
-            .holiday("일요일")
-            .openingHours("11시")
-            .phoneNumber("01012345678")
-            .info("정보")
-            .introduce("introduce")
-            .build();
+                .url("www.example.com")
+                .holiday("일요일")
+                .openingHours("11시")
+                .phoneNumber("01012345678")
+                .info("정보")
+                .introduce("introduce")
+                .build();
 
         var shopAddress = ShopAddress.builder()
-            .address("서울시 강남구")
-            .zipcode("11111")
-            .latitude("123.123")
-            .longitude("123.123")
-            .build();
+                .address("서울시 강남구")
+                .zipcode("11111")
+                .latitude("123.123")
+                .longitude("123.123")
+                .build();
 
         var region = Region.builder()
-            .city("서울시")
-            .district("강남구")
-            .build();
+                .city("서울시")
+                .district("강남구")
+                .build();
 
         Shop shop = Shop.builder()
-            .name("Test Shop")
-            .description("This is a test shop")
-            .shopType(ShopType.KOREAN) // 가정: ShopType 열거형에 TYPE1이 있음
-            .shopDetails(shopDetails)
-            .shopAddress(shopAddress)
-            .region(region)
-            .build();
+                .userId(1L)
+                .name("Test Shop")
+                .description("This is a test shop")
+                .shopType(ShopType.KOREAN) // 가정: ShopType 열거형에 TYPE1이 있음
+                .shopDetails(shopDetails)
+                .shopAddress(shopAddress)
+                .region(region)
+                .build();
 
         // when
         shop.increaseBookmarkCount();
@@ -252,39 +264,42 @@ class ShopTest {
     @DisplayName("북마크 개수가 0일때 감소시키면 예외가 발생한다")
     void bookMarkThrowsExceptionWhenBookMarkCountisZero() {
         // given
+        var userId = 1L;
+
         var shopDetails = ShopDetails.builder()
-            .url("www.example.com")
-            .holiday("일요일")
-            .openingHours("11시")
-            .phoneNumber("01012345678")
-            .info("정보")
-            .introduce("introduce")
-            .build();
+                .url("www.example.com")
+                .holiday("일요일")
+                .openingHours("11시")
+                .phoneNumber("01012345678")
+                .info("정보")
+                .introduce("introduce")
+                .build();
 
         var shopAddress = ShopAddress.builder()
-            .address("서울시 강남구")
-            .zipcode("11111")
-            .latitude("123.123")
-            .longitude("123.123")
-            .build();
+                .address("서울시 강남구")
+                .zipcode("11111")
+                .latitude("123.123")
+                .longitude("123.123")
+                .build();
 
         var region = Region.builder()
-            .city("서울시")
-            .district("강남구")
-            .build();
+                .city("서울시")
+                .district("강남구")
+                .build();
 
         Shop shop = Shop.builder()
-            .name("Test Shop")
-            .description("This is a test shop")
-            .shopType(ShopType.KOREAN)
-            .shopDetails(shopDetails)
-            .shopAddress(shopAddress)
-            .region(region)
-            .build();
+                .userId(1L)
+                .name("Test Shop")
+                .description("This is a test shop")
+                .shopType(ShopType.KOREAN)
+                .shopDetails(shopDetails)
+                .shopAddress(shopAddress)
+                .region(region)
+                .build();
 
         // when&then
         assertThatThrownBy(shop::decreaseBookmarkCount)
-            .isInstanceOf(IllegalStateException.class)
-            .hasMessage("북마크 개수가 0 일 때 북마크 개수를 줄이는 것은 불가능합니다.");
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("북마크 개수가 0 일 때 북마크 개수를 줄이는 것은 불가능합니다.");
     }
 }

--- a/src/test/java/com/mdh/devtable/waiting/ShopWaitingTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/ShopWaitingTest.java
@@ -23,12 +23,12 @@ class ShopWaitingTest {
 
         //when
         var shopWaiting = ShopWaiting
-            .builder()
-            .shopId(shopId)
-            .maximumWaitingPeople(2)
-            .minimumWaitingPeople(1)
-            .maximumWaiting(maximumWaiting)
-            .build();
+                .builder()
+                .shopId(shopId)
+                .maximumWaitingPeople(2)
+                .minimumWaitingPeople(1)
+                .maximumWaiting(maximumWaiting)
+                .build();
 
         //then
         assertThat(shopWaiting.getShopId()).isEqualTo(shopId);
@@ -45,11 +45,11 @@ class ShopWaitingTest {
 
         //when & then
         assertThatThrownBy(() -> ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .build())
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("웨이팅의 최대 인원수는 1 미만 일 수 없습니다.");
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("웨이팅의 최대 인원수는 1 미만 일 수 없습니다.");
     }
 
     @ParameterizedTest
@@ -61,10 +61,10 @@ class ShopWaitingTest {
         var maximumWaiting = 10;
 
         var shopWaiting = ShopWaiting
-            .builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .build();
+                .builder()
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
 
         //when
         shopWaiting.changeShopWaitingStatus(shopWaitingStatus);
@@ -81,15 +81,15 @@ class ShopWaitingTest {
         var maximumWaiting = 10;
 
         var shopWaiting = ShopWaiting
-            .builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .build();
+                .builder()
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
 
         //when & then
         assertThatThrownBy(() -> shopWaiting.changeShopWaitingStatus(shopWaiting.getShopWaitingStatus()))
-            .isInstanceOf(IllegalStateException.class)
-            .hasMessage("매장의 웨이팅 상태를 동일한 상태로 변경 할 수 없습니다.");
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("매장의 웨이팅 상태를 동일한 상태로 변경 할 수 없습니다.");
     }
 
     @ParameterizedTest
@@ -101,10 +101,10 @@ class ShopWaitingTest {
         var maximumWaiting = 10;
 
         var shopWaiting = ShopWaiting
-            .builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .build();
+                .builder()
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
 
         //when
         shopWaiting.updateShopWaiting(changeMaximumWaiting);
@@ -121,15 +121,15 @@ class ShopWaitingTest {
         var maximumWaiting = 10;
 
         var shopWaiting = ShopWaiting
-            .builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .build();
+                .builder()
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
 
         //when & then
         assertThatThrownBy(() -> shopWaiting.updateShopWaiting(0))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("웨이팅의 최대 인원수는 1 미만 일 수 없습니다.");
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("웨이팅의 최대 인원수는 1 미만 일 수 없습니다.");
     }
 
     @Test
@@ -139,9 +139,9 @@ class ShopWaitingTest {
         var shopId = 1L;
         var maximumWaiting = 5;
         var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .build();
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
 
         // when
         var newChildEnabled = true;
@@ -149,5 +149,44 @@ class ShopWaitingTest {
 
         // then
         assertTrue(shopWaiting.isChildEnabled());
+    }
+
+    @Test
+    @DisplayName("매장의 상태가 CLOSE가 되면 매장의 발급번호가 0이 된다.")
+    void initShopWaitingCountTest() {
+        //given
+        var shopId = 1L;
+        var maximumWaiting = 5;
+        var shopWaiting = ShopWaiting.builder()
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
+
+        shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
+
+        //when
+        shopWaiting.addWaitingCount();
+
+        shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.CLOSE);
+
+        //then
+        assertThat(shopWaiting.getWaitingCount()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("매장의 상태가 CLOSE라면 매장의 발급번호 증가 시 예외가 발생한다.")
+    void addShopWaitingCountExTest() {
+        //given
+        var shopId = 1L;
+        var maximumWaiting = 5;
+        var shopWaiting = ShopWaiting.builder()
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
+
+        //when & then
+        assertThatThrownBy(shopWaiting::addWaitingCount)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("닫혀있는 상태에서는 발급번호 개수가 증가할 수 없습니다.");
     }
 }

--- a/src/test/java/com/mdh/devtable/waiting/application/WaitingServiceTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/application/WaitingServiceTest.java
@@ -1,5 +1,11 @@
 package com.mdh.devtable.waiting.application;
 
+import com.mdh.devtable.shop.*;
+import com.mdh.devtable.shop.infra.persistence.RegionRepository;
+import com.mdh.devtable.shop.infra.persistence.ShopRepository;
+import com.mdh.devtable.user.domain.Role;
+import com.mdh.devtable.user.domain.User;
+import com.mdh.devtable.user.infra.persistence.UserRepository;
 import com.mdh.devtable.waiting.domain.ShopWaiting;
 import com.mdh.devtable.waiting.domain.ShopWaitingStatus;
 import com.mdh.devtable.waiting.domain.WaitingStatus;
@@ -14,6 +20,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @Transactional
@@ -21,10 +28,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 class WaitingServiceTest {
 
     @Autowired
-    private WaitingRepository waitingRepository;
+    private UserRepository userRepository;
+
+    @Autowired
+    private RegionRepository regionRepository;
+
+    @Autowired
+    private ShopRepository shopRepository;
 
     @Autowired
     private ShopWaitingRepository shopWaitingRepository;
+
+    @Autowired
+    private WaitingRepository waitingRepository;
 
     @Autowired
     private WaitingService waitingService;
@@ -33,25 +49,37 @@ class WaitingServiceTest {
     @DisplayName("웨이팅을 생성한다.")
     void createWaitingTest() {
         //given
-        var shopId = 1L;
-        var userId = 1L;
+        var ownerId = initUser(Role.OWNER, "owner@example.com");
+
+        var regionId = initRegion();
+        var region = regionRepository.findById(regionId)
+                .orElse(null);
+
+        var shopId = initShop(ownerId, region);
 
         var shopWaiting = ShopWaiting.builder()
-                .shopId(1L)
+                .shopId(shopId)
                 .maximumWaiting(20)
                 .maximumWaitingPeople(7)
                 .minimumWaitingPeople(2)
                 .build();
+
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
         shopWaitingRepository.save(shopWaiting);
 
+        var userId = initUser(Role.GUEST, "guest@example.com");
         var waitingCreateRequest = new WaitingCreateRequest(userId, shopId, 2, 0);
 
         //when
         var waitingId = waitingService.createWaiting(waitingCreateRequest);
+        var findShopWaiting = shopWaitingRepository.findById(shopWaiting.getShopId())
+                .orElse(null);
+        var findWaiting = waitingRepository.findById(waitingId)
+                .orElse(null);
 
         //then
-        var findWaiting = waitingRepository.findById(waitingId).orElse(null);
+        assertThat(findWaiting.getWaitingNumber()).isEqualTo(findShopWaiting.getWaitingCount());
+        assertThat(findWaiting.getWaitingNumber()).isEqualTo(1);
         assertThat(findWaiting).isNotNull();
     }
 
@@ -59,18 +87,25 @@ class WaitingServiceTest {
     @DisplayName("웨이팅을 취소한다.")
     void cancelWaitingTest() {
         //given
-        var shopId = 1L;
-        var userId = 1L;
+        var ownerId = initUser(Role.OWNER, "owner@example.com");
+
+        var regionId = initRegion();
+        var region = regionRepository.findById(regionId)
+                .orElse(null);
+
+        var shopId = initShop(ownerId, region);
 
         var shopWaiting = ShopWaiting.builder()
-                .shopId(1L)
+                .shopId(shopId)
                 .maximumWaiting(20)
                 .maximumWaitingPeople(7)
                 .minimumWaitingPeople(2)
                 .build();
+
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
         shopWaitingRepository.save(shopWaiting);
 
+        var userId = initUser(Role.GUEST, "guest@example.com");
         var waitingCreateRequest = new WaitingCreateRequest(userId, shopId, 2, 0);
         var waitingId = waitingService.createWaiting(waitingCreateRequest);
 
@@ -81,5 +116,88 @@ class WaitingServiceTest {
         var findWaiting = waitingRepository.findById(waitingId)
                 .orElse(null);
         assertThat(findWaiting.getWaitingStatus()).isEqualTo(WaitingStatus.CANCEL);
+    }
+
+    @Test
+    @DisplayName("웨이팅이 등록된 상태에서 웨이팅을 추가로 등록 할 수 없다.")
+    void createWaitingWithProgressingWaitingTest() {
+        //given
+        var ownerId = initUser(Role.OWNER, "owner@example.com");
+
+        var regionId = initRegion();
+        var region = regionRepository.findById(regionId)
+                .orElse(null);
+
+        var shopId = initShop(ownerId, region);
+
+        var shopWaiting = ShopWaiting.builder()
+                .shopId(shopId)
+                .maximumWaiting(20)
+                .maximumWaitingPeople(7)
+                .minimumWaitingPeople(2)
+                .build();
+
+        shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
+        shopWaitingRepository.save(shopWaiting);
+
+        var userId = initUser(Role.GUEST, "guest@example.com");
+
+        var waitingCreateRequest1 = new WaitingCreateRequest(userId, shopId, 2, 0);
+        waitingService.createWaiting(waitingCreateRequest1);
+
+        var waitingCreateRequest2 = new WaitingCreateRequest(userId, shopId, 2, 0);
+
+        //when & then
+        assertThatThrownBy(() -> waitingService.createWaiting(waitingCreateRequest2))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("해당 매장에 이미 웨이팅이 등록되어있다면 웨이팅을 추가로 등록 할 수 없다. userId : " + userId);
+    }
+
+    private Long initUser(Role role, String email) {
+        var user = User.builder()
+                .email(email)
+                .role(role)
+                .password("password123")
+                .build();
+
+        userRepository.save(user);
+        return user.getId();
+    }
+
+    private Long initRegion() {
+        var region = Region.builder()
+                .city("서울시")
+                .district("강남구")
+                .build();
+
+        regionRepository.save(region);
+        return region.getId();
+    }
+
+    private Long initShop(Long userId, Region region) {
+        var shop = Shop.builder()
+                .userId(userId)
+                .name("가게 이름")
+                .description("가게의 간단한 설명")
+                .shopType(ShopType.AMERICAN)
+                .shopDetails(ShopDetails.builder()
+                        .url("https://www.example.com")
+                        .phoneNumber("123-456-7890")
+                        .openingHours("월-토 : 10:00 AM - 9:00 PM")
+                        .holiday("일요일 휴무")
+                        .introduce("이 가게는 맛있는 음식을 제공합니다.")
+                        .info("추가 정보 없음")
+                        .build())
+                .region(region)
+                .shopAddress(ShopAddress.builder()
+                        .address("예시로 123번지")
+                        .zipcode("12345")
+                        .latitude("37.123456")
+                        .longitude("128.124233")
+                        .build())
+                .build();
+
+        shopRepository.save(shop);
+        return shop.getId();
     }
 }


### PR DESCRIPTION
## 🖊️ 1. Changes
- 유저 웨이팅을 발급하는 기능을 추가하였습니다.
- Shop에 User와의 연관관계가 누락되어 있어 추가하였습니다.
- Region의 Repository를 추가하였습니다.
- 이미 Waiting이 등록되어 있는 상태에서 추가로 등록되면 안되므로 이를 검증하기 위한 Validator를 추가하였습니다.

## 🖼️ 2. Screenshot

-

## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer

- 도메인에 외래키가 필요한 경우에는 임시로 값을 넣어주는 형태를 택하였습니다.
- schema에 누락 된 부분이 있었습니다. 데이터에 변경이 있을 시 다음과 같은 순서로 수정을 해야 오류가 없을 것 같습니다.
  1. erdcloud에 필드 추가
  2. schema에 변경 된 필드 반영 
- Shop의 Region이라는 외래키가 중간에 껴있어서 보기가 어려워 상단으로 올렸습니다. 기본키 -> 외래키 -> 일반 필드 순서로 작성하는 것은 어떨까요?

## ✅ 5. Plans
- [ ] - 
- [ ] - 
