### PR TITLE
[MDH-48] feat : 매장 웨이팅 상태 변경 api 기능, 테스트 추가

### DIFF
--- a/src/main/java/com/mdh/devtable/global/handler/GlobalControllerAdvice.java
+++ b/src/main/java/com/mdh/devtable/global/handler/GlobalControllerAdvice.java
@@ -3,14 +3,17 @@ package com.mdh.devtable.global.handler;
 import com.mdh.devtable.global.ApiResponse;
 import com.mdh.devtable.global.error.ValidationError;
 import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.http.HttpStatus;;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.net.URI;
+
 
 @RestControllerAdvice
 public class GlobalControllerAdvice {
@@ -29,5 +32,25 @@ public class GlobalControllerAdvice {
 
         return new ResponseEntity<>(ApiResponse.fail(HttpStatus.BAD_REQUEST.value(),
                 problemDetail), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<ProblemDetail>> handleMessageNotReadable(HttpMessageNotReadableException e, HttpServletRequest request) {
+        var uri = request.getRequestURI();
+        var problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, e.getMessage());
+        problemDetail.setInstance(URI.create(uri));
+        problemDetail.setTitle("HttpMessageNotReadableException");
+
+        return new ResponseEntity<>(ApiResponse.fail(HttpStatus.BAD_REQUEST.value(), problemDetail), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(OptimisticLockingFailureException.class)
+    public ResponseEntity<ApiResponse<ProblemDetail>> handleMessageNotReadable(OptimisticLockingFailureException e, HttpServletRequest request) {
+        var uri = request.getRequestURI();
+        var problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, e.getMessage());
+        problemDetail.setInstance(URI.create(uri));
+        problemDetail.setTitle("OptimisticLockingFailureException");
+
+        return new ResponseEntity<>(ApiResponse.fail(HttpStatus.BAD_REQUEST.value(), problemDetail), HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/com/mdh/devtable/ownerwaitng/presentaion/controller/OwnerWaitingController.java
+++ b/src/main/java/com/mdh/devtable/ownerwaitng/presentaion/controller/OwnerWaitingController.java
@@ -1,0 +1,23 @@
+package com.mdh.devtable.ownerwaitng.presentaion.controller;
+
+import com.mdh.devtable.global.ApiResponse;
+import com.mdh.devtable.ownerwaitng.application.OwnerWaitingService;
+import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/owner/v1")
+public class OwnerWaitingController {
+
+    private final OwnerWaitingService ownerWaitingService;
+
+    @PatchMapping("/shops/{shopId}")
+    public ResponseEntity<ApiResponse<Void>> changShopWaitingStatus(@RequestBody OwnerShopWaitingStatusChangeRequest request, @PathVariable("shopId") Long shopId) {
+        ownerWaitingService.changeShopWaitingStatus(shopId, request);
+        return new ResponseEntity<>(ApiResponse.ok(null), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/mdh/devtable/ownerwaitng/presentaion/dto/OwnerWaitingStatusChangeRequest.java
+++ b/src/main/java/com/mdh/devtable/ownerwaitng/presentaion/dto/OwnerWaitingStatusChangeRequest.java
@@ -1,0 +1,8 @@
+package com.mdh.devtable.ownerwaitng.presentaion.dto;
+
+import com.mdh.devtable.waiting.domain.WaitingStatus;
+
+public record OwnerWaitingStatusChangeRequest(
+        WaitingStatus waitingStatus
+) {
+}

--- a/src/test/java/com/mdh/devtable/ownerwaitng/presentaion/controller/OwnerWaitingControllerTest.java
+++ b/src/test/java/com/mdh/devtable/ownerwaitng/presentaion/controller/OwnerWaitingControllerTest.java
@@ -1,0 +1,92 @@
+package com.mdh.devtable.ownerwaitng.presentaion.controller;
+
+import com.mdh.devtable.RestDocsSupport;
+import com.mdh.devtable.ownerwaitng.application.OwnerWaitingService;
+import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
+import com.mdh.devtable.waiting.domain.ShopWaitingStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import java.util.HashMap;
+
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(OwnerWaitingController.class)
+class OwnerWaitingControllerTest extends RestDocsSupport {
+
+    @Override
+    protected Object initController() {
+        return new OwnerWaitingController(ownerWaitingService);
+    }
+
+    @MockBean
+    private OwnerWaitingService ownerWaitingService;
+
+    @DisplayName("매장의 웨이팅 상태를 변경할 수 있다.")
+    @Test
+    void changShopWaitingStatus() throws Exception {
+        //given
+        var shopId = 1L;
+        var request = new OwnerShopWaitingStatusChangeRequest(ShopWaitingStatus.OPEN);
+        doNothing().when(ownerWaitingService).changeShopWaitingStatus(shopId, request);
+
+        //when & then
+        mockMvc.perform(patch("/api/owner/v1/shops/" + shopId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value("200"))
+                .andExpect(jsonPath("$.data").doesNotExist())
+                .andExpect(jsonPath("$.serverDateTime").exists())
+                .andDo(document("owner-shops-waiting",
+                        requestFields(
+                                fieldWithPath("shopWaitingStatus").type(JsonFieldType.STRING).description("매장 상태")
+                        ),
+                        responseFields(fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("상태 코드"),
+                                fieldWithPath("data").type(JsonFieldType.NULL).description("응답 바디(비어있음)"),
+                                fieldWithPath("serverDateTime").type(JsonFieldType.STRING).description("변경된 서버 시간")
+                        )
+                ));
+    }
+
+    @DisplayName("매장의 웨이팅 상태를 잘못된 형태로 변경할 수 없다.")
+    @Test
+    void changShopWaitingStatusThrowException() throws Exception {
+        //given
+        var shopId = 1L;
+        var request = new HashMap<String, String>();
+        request.put("shopWaitingStatus", "asf");
+
+        //when & then
+        mockMvc.perform(patch("/api/owner/v1/shops/" + shopId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.statusCode").value("400"))
+                .andExpect(jsonPath("$.data.title").value("HttpMessageNotReadableException"))
+                .andDo(document("user-sign-up-invalid-password",
+                        requestFields(
+                                fieldWithPath("shopWaitingStatus").type(JsonFieldType.STRING).description("매장 상태")
+                        ),
+                        responseFields(
+                                fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("상태 코드"),
+                                fieldWithPath("data.type").type(JsonFieldType.STRING).description("타입"),
+                                fieldWithPath("data.title").type(JsonFieldType.STRING).description("타이틀"),
+                                fieldWithPath("data.status").type(JsonFieldType.NUMBER).description("상태 코드"),
+                                fieldWithPath("data.detail").type(JsonFieldType.STRING).description("상세 설명"),
+                                fieldWithPath("data.instance").type(JsonFieldType.STRING).description("인스턴스 URI"),
+                                fieldWithPath("serverDateTime").type(JsonFieldType.STRING).description("서버 시간")
+                        )
+                ));
+    }
+
+}


### PR DESCRIPTION
## 🖊️ 1. Changes

- 매장 웨이팅 상태 변경 api 엔드포인트를 만들었습니다.

## 🖼️ 2. Screenshot

-

## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer

- 이전에 작성한 상태 변경시 락 발생시 글로벌 execption 핸들러에서 잡아주도록 했습니다.
- enum 타입을 잘못 요청 했을 때 spring에서 스스로 잡아줘서 제가 따로 execption 핸들러를 만들어 우리 api의 응답 규칙에 맞게 예외를 잡아줬습니다.(HttpMessageNotReadableException)
- 동시 수정 락 발생 시 api 응답은 테스트 코드로 작성하기 어려워 따로 작성하지 않았습니다.

## ✅ 5. Plans
- [ ] - 웨이팅 상태 변경 기능, api 작성도 이어서 올릴게요
- [ ] - 
