### PR TITLE
[MDH-51] 유저 웨이팅 취소 엔드포인트 구현 및 테스트 

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -14,4 +14,10 @@ endif::[]
 
 [[Hello]]
 == Hello Get 요청
+
 operation::hello[snippets = 'http-request,http-response,request-body,response-fields']
+
+[[Waiting]]
+== Waiting 취소
+
+operation::waiting-cancel[snippets = 'http-request,http-response,request-body,response-fields']

--- a/src/main/java/com/mdh/devtable/shop/Shop.java
+++ b/src/main/java/com/mdh/devtable/shop/Shop.java
@@ -1,22 +1,8 @@
 package com.mdh.devtable.shop;
 
 import com.mdh.devtable.global.BaseTimeEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
+import jakarta.persistence.*;
+import lombok.*;
 
 @Getter
 @Table(name = "shops")
@@ -27,6 +13,13 @@ public class Shop extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "region_id", referencedColumnName = "id")
+    private Region region;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
 
     @Column(name = "name", length = 63, nullable = false)
     private String name;
@@ -50,17 +43,16 @@ public class Shop extends BaseTimeEntity {
     @Embedded
     private ShopAddress shopAddress;
 
-    @ManyToOne
-    @JoinColumn(name = "region_id", referencedColumnName = "id")
-    private Region region;
-
     @Builder
-    public Shop(@NonNull String name,
-                @NonNull String description,
-                @NonNull ShopType shopType,
-                @NonNull ShopDetails shopDetails,
-                @NonNull ShopAddress shopAddress,
-                @NonNull Region region) {
+    public Shop(
+            @NonNull Long userId,
+            @NonNull String name,
+            @NonNull String description,
+            @NonNull ShopType shopType,
+            @NonNull ShopDetails shopDetails,
+            @NonNull ShopAddress shopAddress,
+            @NonNull Region region) {
+        this.userId = userId;
         this.name = name;
         this.description = description;
         this.shopType = shopType;
@@ -71,15 +63,14 @@ public class Shop extends BaseTimeEntity {
         this.region = region;
     }
 
-
     // 비즈니스 메서드
     public void update(
-        @NonNull String name,
-        @NonNull String description,
-        @NonNull ShopType shopType,
-        @NonNull ShopDetails shopDetails,
-        @NonNull ShopAddress shopAddress,
-        @NonNull Region region
+            @NonNull String name,
+            @NonNull String description,
+            @NonNull ShopType shopType,
+            @NonNull ShopDetails shopDetails,
+            @NonNull ShopAddress shopAddress,
+            @NonNull Region region
     ) {
         this.name = name;
         this.description = description;

--- a/src/main/java/com/mdh/devtable/shop/infra/persistence/RegionRepository.java
+++ b/src/main/java/com/mdh/devtable/shop/infra/persistence/RegionRepository.java
@@ -1,0 +1,7 @@
+package com.mdh.devtable.shop.infra.persistence;
+
+import com.mdh.devtable.shop.Region;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RegionRepository extends JpaRepository<Region, Long> {
+}

--- a/src/main/java/com/mdh/devtable/waiting/application/WaitingService.java
+++ b/src/main/java/com/mdh/devtable/waiting/application/WaitingService.java
@@ -19,6 +19,7 @@ public class WaitingService {
 
     private final WaitingRepository waitingRepository;
     private final ShopWaitingRepository shopWaitingRepository;
+    private final WaitingServiceValidator waitingServiceValidator;
     private final WaitingLine waitingLine;
 
     @Transactional
@@ -27,9 +28,17 @@ public class WaitingService {
         var shopWaiting = shopWaitingRepository.findById(shopId)
                 .orElseThrow(() -> new IllegalStateException("해당 매장에 웨이팅 정보가 존재하지 않습니다. shopId : " + shopId));
 
-        var waitingPeople = createWaitingPeople(waitingCreateRequest);
 
         var userId = waitingCreateRequest.userId();
+
+        if (waitingServiceValidator.isExistsWaiting(userId)) {
+            throw new IllegalStateException("해당 매장에 이미 웨이팅이 등록되어있다면 웨이팅을 추가로 등록 할 수 없다. userId : " + userId);
+
+        }
+        shopWaiting.addWaitingCount();
+
+        var waitingPeople = createWaitingPeople(waitingCreateRequest);
+
         var waiting = Waiting.builder()
                 .shopWaiting(shopWaiting)
                 .waitingPeople(waitingPeople)

--- a/src/main/java/com/mdh/devtable/waiting/application/WaitingServiceValidator.java
+++ b/src/main/java/com/mdh/devtable/waiting/application/WaitingServiceValidator.java
@@ -1,0 +1,19 @@
+package com.mdh.devtable.waiting.application;
+
+import com.mdh.devtable.waiting.infra.persistence.WaitingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Component
+public class WaitingServiceValidator {
+
+    private final WaitingRepository waitingRepository;
+
+    @Transactional(readOnly = true)
+    public boolean isExistsWaiting(Long userId) {
+        return waitingRepository.findByProgressWaiting(userId)
+                .isPresent();
+    }
+}

--- a/src/main/java/com/mdh/devtable/waiting/domain/ShopWaiting.java
+++ b/src/main/java/com/mdh/devtable/waiting/domain/ShopWaiting.java
@@ -82,6 +82,10 @@ public class ShopWaiting extends BaseTimeEntity {
     }
 
     public void addWaitingCount() {
+        if (this.shopWaitingStatus.isCloseWaitingStatus()) {
+            throw new IllegalStateException("닫혀있는 상태에서는 발급번호 개수가 증가할 수 없습니다.");
+        }
+
         this.waitingCount++;
     }
 

--- a/src/main/java/com/mdh/devtable/waiting/domain/ShopWaiting.java
+++ b/src/main/java/com/mdh/devtable/waiting/domain/ShopWaiting.java
@@ -17,6 +17,9 @@ public class ShopWaiting extends BaseTimeEntity {
     @Column(name = "shop_id", nullable = false)
     private Long shopId;
 
+    @Column(name = "waiting_count", nullable = false)
+    private int waitingCount;
+
     @Column(name = "status", length = 31, nullable = false)
     @Enumerated(EnumType.STRING)
     private ShopWaitingStatus shopWaitingStatus;
@@ -43,6 +46,7 @@ public class ShopWaiting extends BaseTimeEntity {
                        int maximumWaitingPeople) {
         validMaximumWaiting(maximumWaiting);
         this.shopId = shopId;
+        this.waitingCount = 0;
         this.maximumWaiting = maximumWaiting;
         this.shopWaitingStatus = ShopWaitingStatus.CLOSE;
         this.childEnabled = false;
@@ -66,11 +70,19 @@ public class ShopWaiting extends BaseTimeEntity {
             throw new IllegalStateException("매장의 웨이팅 상태를 동일한 상태로 변경 할 수 없습니다.");
         }
 
+        if (shopWaitingStatus.isCloseWaitingStatus()) {
+            this.waitingCount = 0;
+        }
+
         this.shopWaitingStatus = shopWaitingStatus;
     }
 
     public boolean isOpenWaitingStatus() {
         return this.shopWaitingStatus == ShopWaitingStatus.OPEN;
+    }
+
+    public void addWaitingCount() {
+        this.waitingCount++;
     }
 
     public void updateChildEnabled(boolean childEnabled) {

--- a/src/main/java/com/mdh/devtable/waiting/domain/ShopWaitingStatus.java
+++ b/src/main/java/com/mdh/devtable/waiting/domain/ShopWaitingStatus.java
@@ -9,4 +9,8 @@ public enum ShopWaitingStatus {
     CLOSE("영업 종료");
 
     private final String statusMessage;
+
+    public boolean isCloseWaitingStatus() {
+        return this == ShopWaitingStatus.CLOSE;
+    }
 }

--- a/src/main/java/com/mdh/devtable/waiting/domain/Waiting.java
+++ b/src/main/java/com/mdh/devtable/waiting/domain/Waiting.java
@@ -1,17 +1,7 @@
 package com.mdh.devtable.waiting.domain;
 
 import com.mdh.devtable.global.BaseTimeEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,6 +24,9 @@ public class Waiting extends BaseTimeEntity {
     @Column(name = "user_id")
     private Long userId;
 
+    @Column(name = "waiting_number", nullable = false)
+    private int waitingNumber;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "waiting_status", length = 31, nullable = false)
     private WaitingStatus waitingStatus;
@@ -54,6 +47,7 @@ public class Waiting extends BaseTimeEntity {
         validChildEnable(shopWaiting, waitingPeople);
         this.shopWaiting = shopWaiting;
         this.userId = userId;
+        this.waitingNumber = shopWaiting.getWaitingCount();
         this.waitingStatus = WaitingStatus.PROGRESS;
         this.postponedCount = 0;
         this.waitingPeople = waitingPeople;

--- a/src/main/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepository.java
+++ b/src/main/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepository.java
@@ -2,6 +2,13 @@ package com.mdh.devtable.waiting.infra.persistence;
 
 import com.mdh.devtable.waiting.domain.Waiting;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface WaitingRepository extends JpaRepository<Waiting, Long> {
+
+    @Query("select w from Waiting w where w.waitingStatus = 'PROGRESS' and w.userId = :userId")
+    Optional<Waiting> findByProgressWaiting(@Param("userId") Long userId);
 }

--- a/src/main/java/com/mdh/devtable/waiting/presentation/UserWaitingController.java
+++ b/src/main/java/com/mdh/devtable/waiting/presentation/UserWaitingController.java
@@ -7,10 +7,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -26,5 +23,11 @@ public class UserWaitingController {
         Long waitingId = waitingService.createWaiting(waitingCreateRequest);
         var createdResponse = ApiResponse.created(URI.create("/api/customer/v1/waitings" + waitingId));
         return new ResponseEntity<>(createdResponse, HttpStatus.CREATED);
+    }
+
+    @PatchMapping("/{waitingId}")
+    public ResponseEntity<ApiResponse<Void>> cancelWaiting(@PathVariable Long waitingId) {
+        waitingService.cancelWaiting(waitingId);
+        return new ResponseEntity<>(ApiResponse.noContent(null), HttpStatus.NO_CONTENT);
     }
 }

--- a/src/test/java/com/mdh/devtable/shop/ShopTest.java
+++ b/src/test/java/com/mdh/devtable/shop/ShopTest.java
@@ -14,53 +14,56 @@ class ShopTest {
     @DisplayName("Shop을 생성하면 북마크 수는 0이어야 한다")
     void shopConstructorTest() {
         // given
+        var userId = 1L;
+
         var shopDetails = ShopDetails.builder()
-            .url("www.example.com")
-            .holiday("일요일")
-            .openingHours("11시")
-            .phoneNumber("01012345678")
-            .info("정보")
-            .introduce("introduce")
-            .build();
+                .url("www.example.com")
+                .holiday("일요일")
+                .openingHours("11시")
+                .phoneNumber("01012345678")
+                .info("정보")
+                .introduce("introduce")
+                .build();
 
         var shopAddress = ShopAddress.builder()
-            .address("가로수길 31-3, 301호")
-            .zipcode("11111")
-            .latitude("123.123")
-            .longitude("123.123")
-            .build();
+                .address("가로수길 31-3, 301호")
+                .zipcode("11111")
+                .latitude("123.123")
+                .longitude("123.123")
+                .build();
 
         var region = Region.builder()
-            .city("서울시")
-            .district("강남구")
-            .build();
+                .city("서울시")
+                .district("강남구")
+                .build();
 
         // when
         Shop shop = Shop.builder()
-            .name("Test Shop")
-            .description("This is a test shop")
-            .shopType(ShopType.KOREAN) // 가정: ShopType 열거형에 TYPE1이 있음
-            .shopDetails(shopDetails)
-            .shopAddress(shopAddress)
-            .region(region)
-            .build();
+                .userId(userId)
+                .name("Test Shop")
+                .description("This is a test shop")
+                .shopType(ShopType.KOREAN) // 가정: ShopType 열거형에 TYPE1이 있음
+                .shopDetails(shopDetails)
+                .shopAddress(shopAddress)
+                .region(region)
+                .build();
 
         // then
         assertThat(shop)
-            .extracting(Shop::getBookmarkCount,
-                Shop::getName,
-                Shop::getDescription,
-                Shop::getShopType,
-                Shop::getShopDetails,
-                Shop::getShopAddress,
-                Shop::getRegion)
-            .containsExactly(0,
-                "Test Shop",
-                "This is a test shop",
-                ShopType.KOREAN,
-                shopDetails,
-                shopAddress,
-                region);
+                .extracting(Shop::getBookmarkCount,
+                        Shop::getName,
+                        Shop::getDescription,
+                        Shop::getShopType,
+                        Shop::getShopDetails,
+                        Shop::getShopAddress,
+                        Shop::getRegion)
+                .containsExactly(0,
+                        "Test Shop",
+                        "This is a test shop",
+                        ShopType.KOREAN,
+                        shopDetails,
+                        shopAddress,
+                        region);
     }
 
     @Disabled
@@ -75,85 +78,88 @@ class ShopTest {
     @DisplayName("Shop의 정보를 수정한다.")
     void updateShopInfo() {
         // given
+        var userId = 1L;
+
         var shopDetails = ShopDetails.builder()
-            .url("www.example.com")
-            .holiday("일요일")
-            .openingHours("11시")
-            .phoneNumber("01012345678")
-            .info("정보")
-            .introduce("introduce")
-            .build();
+                .url("www.example.com")
+                .holiday("일요일")
+                .openingHours("11시")
+                .phoneNumber("01012345678")
+                .info("정보")
+                .introduce("introduce")
+                .build();
 
         var shopAddress = ShopAddress.builder()
-            .address("잠실로 62, 302동 202호")
-            .zipcode("11111")
-            .latitude("123.123")
-            .longitude("123.123")
-            .build();
+                .address("잠실로 62, 302동 202호")
+                .zipcode("11111")
+                .latitude("123.123")
+                .longitude("123.123")
+                .build();
 
         var region = Region.builder()
-            .city("서울시")
-            .district("강남구")
-            .build();
+                .city("서울시")
+                .district("강남구")
+                .build();
 
         Shop shop = Shop.builder()
-            .name("Test Shop")
-            .description("This is a test shop")
-            .shopType(ShopType.KOREAN) // 가정: ShopType 열거형에 TYPE1이 있음
-            .shopDetails(shopDetails)
-            .shopAddress(shopAddress)
-            .region(region)
-            .build();
+                .userId(1L)
+                .name("Test Shop")
+                .description("This is a test shop")
+                .shopType(ShopType.KOREAN) // 가정: ShopType 열거형에 TYPE1이 있음
+                .shopDetails(shopDetails)
+                .shopAddress(shopAddress)
+                .region(region)
+                .build();
 
         String changeName = "changedName";
         String changeDescription = "changedDescription";
         ShopType changeShopType = ShopType.ASIAN;
 
         var changeShopDetails = ShopDetails.builder()
-            .url("www.change.com")
-            .holiday("일요일")
-            .openingHours("12시")
-            .phoneNumber("01012345678")
-            .info("정보")
-            .introduce("introduce")
-            .build();
+                .url("www.change.com")
+                .holiday("일요일")
+                .openingHours("12시")
+                .phoneNumber("01012345678")
+                .info("정보")
+                .introduce("introduce")
+                .build();
 
         var changeShopAddress = ShopAddress.builder()
-            .address("서울시 송파구")
-            .zipcode("12345")
-            .latitude("123.345")
-            .longitude("123.127")
-            .build();
+                .address("서울시 송파구")
+                .zipcode("12345")
+                .latitude("123.345")
+                .longitude("123.127")
+                .build();
 
         var changeRegion = Region.builder()
-            .city("서울")
-            .district("송파구")
-            .build();
+                .city("서울")
+                .district("송파구")
+                .build();
 
         // when
         shop.update(changeName,
-            changeDescription,
-            changeShopType,
-            changeShopDetails,
-            changeShopAddress,
-            changeRegion);
-
-        // then
-        assertThat(shop)
-            .extracting(Shop::getBookmarkCount,
-                Shop::getName,
-                Shop::getDescription,
-                Shop::getShopType,
-                Shop::getShopDetails,
-                Shop::getShopAddress,
-                Shop::getRegion)
-            .containsExactly(0,
-                changeName,
                 changeDescription,
                 changeShopType,
                 changeShopDetails,
                 changeShopAddress,
                 changeRegion);
+
+        // then
+        assertThat(shop)
+                .extracting(Shop::getBookmarkCount,
+                        Shop::getName,
+                        Shop::getDescription,
+                        Shop::getShopType,
+                        Shop::getShopDetails,
+                        Shop::getShopAddress,
+                        Shop::getRegion)
+                .containsExactly(0,
+                        changeName,
+                        changeDescription,
+                        changeShopType,
+                        changeShopDetails,
+                        changeShopAddress,
+                        changeRegion);
     }
 
     @Disabled
@@ -169,35 +175,38 @@ class ShopTest {
     @DisplayName("북마크 개수를 증가시킨다.")
     void increaseBookMarks() {
         // given
+        var userId = 1L;
+
         var shopDetails = ShopDetails.builder()
-            .url("www.example.com")
-            .holiday("일요일")
-            .openingHours("11시")
-            .phoneNumber("01012345678")
-            .info("정보")
-            .introduce("introduce")
-            .build();
+                .url("www.example.com")
+                .holiday("일요일")
+                .openingHours("11시")
+                .phoneNumber("01012345678")
+                .info("정보")
+                .introduce("introduce")
+                .build();
 
         var shopAddress = ShopAddress.builder()
-            .address("서울시 강남구")
-            .zipcode("11111")
-            .latitude("123.123")
-            .longitude("123.123")
-            .build();
+                .address("서울시 강남구")
+                .zipcode("11111")
+                .latitude("123.123")
+                .longitude("123.123")
+                .build();
 
         var region = Region.builder()
-            .city("서울시")
-            .district("강남구")
-            .build();
+                .city("서울시")
+                .district("강남구")
+                .build();
 
         Shop shop = Shop.builder()
-            .name("Test Shop")
-            .description("This is a test shop")
-            .shopType(ShopType.KOREAN)
-            .shopDetails(shopDetails)
-            .shopAddress(shopAddress)
-            .region(region)
-            .build();
+                .userId(1L)
+                .name("Test Shop")
+                .description("This is a test shop")
+                .shopType(ShopType.KOREAN)
+                .shopDetails(shopDetails)
+                .shopAddress(shopAddress)
+                .region(region)
+                .build();
 
         // when
         shop.increaseBookmarkCount();
@@ -210,35 +219,38 @@ class ShopTest {
     @DisplayName("북마크 개수를 감소시킨다.")
     void decreaseBookMarks() {
         // given
+        var userId = 1L;
+
         var shopDetails = ShopDetails.builder()
-            .url("www.example.com")
-            .holiday("일요일")
-            .openingHours("11시")
-            .phoneNumber("01012345678")
-            .info("정보")
-            .introduce("introduce")
-            .build();
+                .url("www.example.com")
+                .holiday("일요일")
+                .openingHours("11시")
+                .phoneNumber("01012345678")
+                .info("정보")
+                .introduce("introduce")
+                .build();
 
         var shopAddress = ShopAddress.builder()
-            .address("서울시 강남구")
-            .zipcode("11111")
-            .latitude("123.123")
-            .longitude("123.123")
-            .build();
+                .address("서울시 강남구")
+                .zipcode("11111")
+                .latitude("123.123")
+                .longitude("123.123")
+                .build();
 
         var region = Region.builder()
-            .city("서울시")
-            .district("강남구")
-            .build();
+                .city("서울시")
+                .district("강남구")
+                .build();
 
         Shop shop = Shop.builder()
-            .name("Test Shop")
-            .description("This is a test shop")
-            .shopType(ShopType.KOREAN) // 가정: ShopType 열거형에 TYPE1이 있음
-            .shopDetails(shopDetails)
-            .shopAddress(shopAddress)
-            .region(region)
-            .build();
+                .userId(1L)
+                .name("Test Shop")
+                .description("This is a test shop")
+                .shopType(ShopType.KOREAN) // 가정: ShopType 열거형에 TYPE1이 있음
+                .shopDetails(shopDetails)
+                .shopAddress(shopAddress)
+                .region(region)
+                .build();
 
         // when
         shop.increaseBookmarkCount();
@@ -252,39 +264,42 @@ class ShopTest {
     @DisplayName("북마크 개수가 0일때 감소시키면 예외가 발생한다")
     void bookMarkThrowsExceptionWhenBookMarkCountisZero() {
         // given
+        var userId = 1L;
+
         var shopDetails = ShopDetails.builder()
-            .url("www.example.com")
-            .holiday("일요일")
-            .openingHours("11시")
-            .phoneNumber("01012345678")
-            .info("정보")
-            .introduce("introduce")
-            .build();
+                .url("www.example.com")
+                .holiday("일요일")
+                .openingHours("11시")
+                .phoneNumber("01012345678")
+                .info("정보")
+                .introduce("introduce")
+                .build();
 
         var shopAddress = ShopAddress.builder()
-            .address("서울시 강남구")
-            .zipcode("11111")
-            .latitude("123.123")
-            .longitude("123.123")
-            .build();
+                .address("서울시 강남구")
+                .zipcode("11111")
+                .latitude("123.123")
+                .longitude("123.123")
+                .build();
 
         var region = Region.builder()
-            .city("서울시")
-            .district("강남구")
-            .build();
+                .city("서울시")
+                .district("강남구")
+                .build();
 
         Shop shop = Shop.builder()
-            .name("Test Shop")
-            .description("This is a test shop")
-            .shopType(ShopType.KOREAN)
-            .shopDetails(shopDetails)
-            .shopAddress(shopAddress)
-            .region(region)
-            .build();
+                .userId(1L)
+                .name("Test Shop")
+                .description("This is a test shop")
+                .shopType(ShopType.KOREAN)
+                .shopDetails(shopDetails)
+                .shopAddress(shopAddress)
+                .region(region)
+                .build();
 
         // when&then
         assertThatThrownBy(shop::decreaseBookmarkCount)
-            .isInstanceOf(IllegalStateException.class)
-            .hasMessage("북마크 개수가 0 일 때 북마크 개수를 줄이는 것은 불가능합니다.");
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("북마크 개수가 0 일 때 북마크 개수를 줄이는 것은 불가능합니다.");
     }
 }

--- a/src/test/java/com/mdh/devtable/waiting/ShopWaitingTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/ShopWaitingTest.java
@@ -23,12 +23,12 @@ class ShopWaitingTest {
 
         //when
         var shopWaiting = ShopWaiting
-            .builder()
-            .shopId(shopId)
-            .maximumWaitingPeople(2)
-            .minimumWaitingPeople(1)
-            .maximumWaiting(maximumWaiting)
-            .build();
+                .builder()
+                .shopId(shopId)
+                .maximumWaitingPeople(2)
+                .minimumWaitingPeople(1)
+                .maximumWaiting(maximumWaiting)
+                .build();
 
         //then
         assertThat(shopWaiting.getShopId()).isEqualTo(shopId);
@@ -45,11 +45,11 @@ class ShopWaitingTest {
 
         //when & then
         assertThatThrownBy(() -> ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .build())
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("웨이팅의 최대 인원수는 1 미만 일 수 없습니다.");
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("웨이팅의 최대 인원수는 1 미만 일 수 없습니다.");
     }
 
     @ParameterizedTest
@@ -61,10 +61,10 @@ class ShopWaitingTest {
         var maximumWaiting = 10;
 
         var shopWaiting = ShopWaiting
-            .builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .build();
+                .builder()
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
 
         //when
         shopWaiting.changeShopWaitingStatus(shopWaitingStatus);
@@ -81,15 +81,15 @@ class ShopWaitingTest {
         var maximumWaiting = 10;
 
         var shopWaiting = ShopWaiting
-            .builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .build();
+                .builder()
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
 
         //when & then
         assertThatThrownBy(() -> shopWaiting.changeShopWaitingStatus(shopWaiting.getShopWaitingStatus()))
-            .isInstanceOf(IllegalStateException.class)
-            .hasMessage("매장의 웨이팅 상태를 동일한 상태로 변경 할 수 없습니다.");
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("매장의 웨이팅 상태를 동일한 상태로 변경 할 수 없습니다.");
     }
 
     @ParameterizedTest
@@ -101,10 +101,10 @@ class ShopWaitingTest {
         var maximumWaiting = 10;
 
         var shopWaiting = ShopWaiting
-            .builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .build();
+                .builder()
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
 
         //when
         shopWaiting.updateShopWaiting(changeMaximumWaiting);
@@ -121,15 +121,15 @@ class ShopWaitingTest {
         var maximumWaiting = 10;
 
         var shopWaiting = ShopWaiting
-            .builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .build();
+                .builder()
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
 
         //when & then
         assertThatThrownBy(() -> shopWaiting.updateShopWaiting(0))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("웨이팅의 최대 인원수는 1 미만 일 수 없습니다.");
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("웨이팅의 최대 인원수는 1 미만 일 수 없습니다.");
     }
 
     @Test
@@ -139,9 +139,9 @@ class ShopWaitingTest {
         var shopId = 1L;
         var maximumWaiting = 5;
         var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .build();
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
 
         // when
         var newChildEnabled = true;
@@ -149,5 +149,44 @@ class ShopWaitingTest {
 
         // then
         assertTrue(shopWaiting.isChildEnabled());
+    }
+
+    @Test
+    @DisplayName("매장의 상태가 CLOSE가 되면 매장의 발급번호가 0이 된다.")
+    void initShopWaitingCountTest() {
+        //given
+        var shopId = 1L;
+        var maximumWaiting = 5;
+        var shopWaiting = ShopWaiting.builder()
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
+
+        shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
+
+        //when
+        shopWaiting.addWaitingCount();
+
+        shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.CLOSE);
+
+        //then
+        assertThat(shopWaiting.getWaitingCount()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("매장의 상태가 CLOSE라면 매장의 발급번호 증가 시 예외가 발생한다.")
+    void addShopWaitingCountExTest() {
+        //given
+        var shopId = 1L;
+        var maximumWaiting = 5;
+        var shopWaiting = ShopWaiting.builder()
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .build();
+
+        //when & then
+        assertThatThrownBy(shopWaiting::addWaitingCount)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("닫혀있는 상태에서는 발급번호 개수가 증가할 수 없습니다.");
     }
 }

--- a/src/test/java/com/mdh/devtable/waiting/application/WaitingServiceTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/application/WaitingServiceTest.java
@@ -1,5 +1,11 @@
 package com.mdh.devtable.waiting.application;
 
+import com.mdh.devtable.shop.*;
+import com.mdh.devtable.shop.infra.persistence.RegionRepository;
+import com.mdh.devtable.shop.infra.persistence.ShopRepository;
+import com.mdh.devtable.user.domain.Role;
+import com.mdh.devtable.user.domain.User;
+import com.mdh.devtable.user.infra.persistence.UserRepository;
 import com.mdh.devtable.waiting.domain.ShopWaiting;
 import com.mdh.devtable.waiting.domain.ShopWaitingStatus;
 import com.mdh.devtable.waiting.domain.WaitingStatus;
@@ -14,6 +20,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @Transactional
@@ -21,10 +28,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 class WaitingServiceTest {
 
     @Autowired
-    private WaitingRepository waitingRepository;
+    private UserRepository userRepository;
+
+    @Autowired
+    private RegionRepository regionRepository;
+
+    @Autowired
+    private ShopRepository shopRepository;
 
     @Autowired
     private ShopWaitingRepository shopWaitingRepository;
+
+    @Autowired
+    private WaitingRepository waitingRepository;
 
     @Autowired
     private WaitingService waitingService;
@@ -33,25 +49,37 @@ class WaitingServiceTest {
     @DisplayName("웨이팅을 생성한다.")
     void createWaitingTest() {
         //given
-        var shopId = 1L;
-        var userId = 1L;
+        var ownerId = initUser(Role.OWNER, "owner@example.com");
+
+        var regionId = initRegion();
+        var region = regionRepository.findById(regionId)
+                .orElse(null);
+
+        var shopId = initShop(ownerId, region);
 
         var shopWaiting = ShopWaiting.builder()
-                .shopId(1L)
+                .shopId(shopId)
                 .maximumWaiting(20)
                 .maximumWaitingPeople(7)
                 .minimumWaitingPeople(2)
                 .build();
+
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
         shopWaitingRepository.save(shopWaiting);
 
+        var userId = initUser(Role.GUEST, "guest@example.com");
         var waitingCreateRequest = new WaitingCreateRequest(userId, shopId, 2, 0);
 
         //when
         var waitingId = waitingService.createWaiting(waitingCreateRequest);
+        var findShopWaiting = shopWaitingRepository.findById(shopWaiting.getShopId())
+                .orElse(null);
+        var findWaiting = waitingRepository.findById(waitingId)
+                .orElse(null);
 
         //then
-        var findWaiting = waitingRepository.findById(waitingId).orElse(null);
+        assertThat(findWaiting.getWaitingNumber()).isEqualTo(findShopWaiting.getWaitingCount());
+        assertThat(findWaiting.getWaitingNumber()).isEqualTo(1);
         assertThat(findWaiting).isNotNull();
     }
 
@@ -59,18 +87,25 @@ class WaitingServiceTest {
     @DisplayName("웨이팅을 취소한다.")
     void cancelWaitingTest() {
         //given
-        var shopId = 1L;
-        var userId = 1L;
+        var ownerId = initUser(Role.OWNER, "owner@example.com");
+
+        var regionId = initRegion();
+        var region = regionRepository.findById(regionId)
+                .orElse(null);
+
+        var shopId = initShop(ownerId, region);
 
         var shopWaiting = ShopWaiting.builder()
-                .shopId(1L)
+                .shopId(shopId)
                 .maximumWaiting(20)
                 .maximumWaitingPeople(7)
                 .minimumWaitingPeople(2)
                 .build();
+
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
         shopWaitingRepository.save(shopWaiting);
 
+        var userId = initUser(Role.GUEST, "guest@example.com");
         var waitingCreateRequest = new WaitingCreateRequest(userId, shopId, 2, 0);
         var waitingId = waitingService.createWaiting(waitingCreateRequest);
 
@@ -81,5 +116,88 @@ class WaitingServiceTest {
         var findWaiting = waitingRepository.findById(waitingId)
                 .orElse(null);
         assertThat(findWaiting.getWaitingStatus()).isEqualTo(WaitingStatus.CANCEL);
+    }
+
+    @Test
+    @DisplayName("웨이팅이 등록된 상태에서 웨이팅을 추가로 등록 할 수 없다.")
+    void createWaitingWithProgressingWaitingTest() {
+        //given
+        var ownerId = initUser(Role.OWNER, "owner@example.com");
+
+        var regionId = initRegion();
+        var region = regionRepository.findById(regionId)
+                .orElse(null);
+
+        var shopId = initShop(ownerId, region);
+
+        var shopWaiting = ShopWaiting.builder()
+                .shopId(shopId)
+                .maximumWaiting(20)
+                .maximumWaitingPeople(7)
+                .minimumWaitingPeople(2)
+                .build();
+
+        shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
+        shopWaitingRepository.save(shopWaiting);
+
+        var userId = initUser(Role.GUEST, "guest@example.com");
+
+        var waitingCreateRequest1 = new WaitingCreateRequest(userId, shopId, 2, 0);
+        waitingService.createWaiting(waitingCreateRequest1);
+
+        var waitingCreateRequest2 = new WaitingCreateRequest(userId, shopId, 2, 0);
+
+        //when & then
+        assertThatThrownBy(() -> waitingService.createWaiting(waitingCreateRequest2))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("해당 매장에 이미 웨이팅이 등록되어있다면 웨이팅을 추가로 등록 할 수 없다. userId : " + userId);
+    }
+
+    private Long initUser(Role role, String email) {
+        var user = User.builder()
+                .email(email)
+                .role(role)
+                .password("password123")
+                .build();
+
+        userRepository.save(user);
+        return user.getId();
+    }
+
+    private Long initRegion() {
+        var region = Region.builder()
+                .city("서울시")
+                .district("강남구")
+                .build();
+
+        regionRepository.save(region);
+        return region.getId();
+    }
+
+    private Long initShop(Long userId, Region region) {
+        var shop = Shop.builder()
+                .userId(userId)
+                .name("가게 이름")
+                .description("가게의 간단한 설명")
+                .shopType(ShopType.AMERICAN)
+                .shopDetails(ShopDetails.builder()
+                        .url("https://www.example.com")
+                        .phoneNumber("123-456-7890")
+                        .openingHours("월-토 : 10:00 AM - 9:00 PM")
+                        .holiday("일요일 휴무")
+                        .introduce("이 가게는 맛있는 음식을 제공합니다.")
+                        .info("추가 정보 없음")
+                        .build())
+                .region(region)
+                .shopAddress(ShopAddress.builder()
+                        .address("예시로 123번지")
+                        .zipcode("12345")
+                        .latitude("37.123456")
+                        .longitude("128.124233")
+                        .build())
+                .build();
+
+        shopRepository.save(shop);
+        return shop.getId();
     }
 }

--- a/src/test/java/com/mdh/devtable/waiting/presentation/UserWaitingControllerTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/presentation/UserWaitingControllerTest.java
@@ -15,8 +15,10 @@ import org.springframework.restdocs.payload.JsonFieldType;
 
 import java.util.stream.Stream;
 
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -44,26 +46,26 @@ class UserWaitingControllerTest extends RestDocsSupport {
 
         //when & then
         mockMvc.perform(post("/api/customer/v1/waitings")
-                .content(objectMapper.writeValueAsString(waitingCreateRequest))
-                .contentType(MediaType.APPLICATION_JSON))
-            .andDo(print())
-            .andExpect(status().isCreated())
-            .andExpect(jsonPath("$.statusCode").value("201"))
-            .andExpect(jsonPath("$.data").value("/api/customer/v1/waitings" + waitingId))
-            .andExpect(jsonPath("$.serverDateTime").exists())
-            .andDo(document("waiting-create",
-                requestFields(
-                    fieldWithPath("userId").type(JsonFieldType.NUMBER).description("유저 아이디"),
-                    fieldWithPath("shopId").type(JsonFieldType.NUMBER).description("매장 아이디"),
-                    fieldWithPath("adultCount").type(JsonFieldType.NUMBER).description("어른 인원 수"),
-                    fieldWithPath("childCount").type(JsonFieldType.NUMBER).description("유아 인원 수")
-                ),
-                responseFields(
-                    fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("상태 코드"),
-                    fieldWithPath("data").type(JsonFieldType.STRING).description("생성된 URI + id"),
-                    fieldWithPath("serverDateTime").type(JsonFieldType.STRING).description("생성된 서버 시간")
-                )
-            ));
+                        .content(objectMapper.writeValueAsString(waitingCreateRequest))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.statusCode").value("201"))
+                .andExpect(jsonPath("$.data").value("/api/customer/v1/waitings" + waitingId))
+                .andExpect(jsonPath("$.serverDateTime").exists())
+                .andDo(document("waiting-create",
+                        requestFields(
+                                fieldWithPath("userId").type(JsonFieldType.NUMBER).description("유저 아이디"),
+                                fieldWithPath("shopId").type(JsonFieldType.NUMBER).description("매장 아이디"),
+                                fieldWithPath("adultCount").type(JsonFieldType.NUMBER).description("어른 인원 수"),
+                                fieldWithPath("childCount").type(JsonFieldType.NUMBER).description("유아 인원 수")
+                        ),
+                        responseFields(
+                                fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("상태 코드"),
+                                fieldWithPath("data").type(JsonFieldType.STRING).description("생성된 URI + id"),
+                                fieldWithPath("serverDateTime").type(JsonFieldType.STRING).description("생성된 서버 시간")
+                        )
+                ));
     }
 
     @ParameterizedTest
@@ -74,39 +76,39 @@ class UserWaitingControllerTest extends RestDocsSupport {
 
         // when & then
         mockMvc.perform(post("/api/customer/v1/waitings")
-                .content(objectMapper.writeValueAsString(waitingCreateRequest))
-                .contentType(MediaType.APPLICATION_JSON))
-            .andDo(print())
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.statusCode").value("400"))
-            .andExpect(jsonPath("$.data.title").value("MethodArgumentNotValidException"))
-            .andDo(document("waiting-create-valid-count",
-                requestFields(
-                    fieldWithPath("userId").type(JsonFieldType.NUMBER).description("유저 아이디"),
-                    fieldWithPath("shopId").type(JsonFieldType.NUMBER).description("매장 아이디"),
-                    fieldWithPath("adultCount").type(JsonFieldType.NUMBER).description("어른 인원 수"),
-                    fieldWithPath("childCount").type(JsonFieldType.NUMBER).description("유아 인원 수")
-                ),
-                responseFields(
-                    fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("상태 코드"),
-                    fieldWithPath("data.type").type(JsonFieldType.STRING).description("타입"),
-                    fieldWithPath("data.title").type(JsonFieldType.STRING).description("타이틀"),
-                    fieldWithPath("data.status").type(JsonFieldType.NUMBER).description("상태 코드"),
-                    fieldWithPath("data.detail").type(JsonFieldType.STRING).description("상세 설명"),
-                    fieldWithPath("data.instance").type(JsonFieldType.STRING).description("인스턴스 URI"),
-                    fieldWithPath("data.validationError[].field").type(JsonFieldType.STRING).description("유효성 검사 실패 필드"),
-                    fieldWithPath("data.validationError[].message").type(JsonFieldType.STRING).description("유효성 검사 실패 메시지"),
-                    fieldWithPath("serverDateTime").type(JsonFieldType.STRING).description("서버 시간")
-                )
-            ));
+                        .content(objectMapper.writeValueAsString(waitingCreateRequest))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.statusCode").value("400"))
+                .andExpect(jsonPath("$.data.title").value("MethodArgumentNotValidException"))
+                .andDo(document("waiting-create-valid-count",
+                        requestFields(
+                                fieldWithPath("userId").type(JsonFieldType.NUMBER).description("유저 아이디"),
+                                fieldWithPath("shopId").type(JsonFieldType.NUMBER).description("매장 아이디"),
+                                fieldWithPath("adultCount").type(JsonFieldType.NUMBER).description("어른 인원 수"),
+                                fieldWithPath("childCount").type(JsonFieldType.NUMBER).description("유아 인원 수")
+                        ),
+                        responseFields(
+                                fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("상태 코드"),
+                                fieldWithPath("data.type").type(JsonFieldType.STRING).description("타입"),
+                                fieldWithPath("data.title").type(JsonFieldType.STRING).description("타이틀"),
+                                fieldWithPath("data.status").type(JsonFieldType.NUMBER).description("상태 코드"),
+                                fieldWithPath("data.detail").type(JsonFieldType.STRING).description("상세 설명"),
+                                fieldWithPath("data.instance").type(JsonFieldType.STRING).description("인스턴스 URI"),
+                                fieldWithPath("data.validationError[].field").type(JsonFieldType.STRING).description("유효성 검사 실패 필드"),
+                                fieldWithPath("data.validationError[].message").type(JsonFieldType.STRING).description("유효성 검사 실패 메시지"),
+                                fieldWithPath("serverDateTime").type(JsonFieldType.STRING).description("서버 시간")
+                        )
+                ));
     }
 
     static Stream<Arguments> provideWaitingCreateOutOfRangeCount() {
         return Stream.of(
-            Arguments.arguments(new WaitingCreateRequest(1L, 1L, -1, 0)),
-            Arguments.arguments(new WaitingCreateRequest(1L, 1L, 31, 0)),
-            Arguments.arguments(new WaitingCreateRequest(1L, 1L, 0, -1)),
-            Arguments.arguments(new WaitingCreateRequest(1L, 1L, 0, 31))
+                Arguments.arguments(new WaitingCreateRequest(1L, 1L, -1, 0)),
+                Arguments.arguments(new WaitingCreateRequest(1L, 1L, 31, 0)),
+                Arguments.arguments(new WaitingCreateRequest(1L, 1L, 0, -1)),
+                Arguments.arguments(new WaitingCreateRequest(1L, 1L, 0, 31))
         );
     }
 
@@ -118,37 +120,61 @@ class UserWaitingControllerTest extends RestDocsSupport {
 
         // when & then
         mockMvc.perform(post("/api/customer/v1/waitings")
-                .content(objectMapper.writeValueAsString(waitingCreateRequest))
-                .contentType(MediaType.APPLICATION_JSON))
-            .andDo(print())
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.statusCode").value("400"))
-            .andExpect(jsonPath("$.data.title").value("MethodArgumentNotValidException"))
-            .andDo(document("waiting-create-valid-null",
-                requestFields(
-                    fieldWithPath("userId").type(JsonFieldType.VARIES).description("유저 아이디"),
-                    fieldWithPath("shopId").type(JsonFieldType.VARIES).description("매장 아이디"),
-                    fieldWithPath("adultCount").type(JsonFieldType.NUMBER).description("어른 인원 수"),
-                    fieldWithPath("childCount").type(JsonFieldType.NUMBER).description("유아 인원 수")
-                ),
-                responseFields(
-                    fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("상태 코드"),
-                    fieldWithPath("data.type").type(JsonFieldType.STRING).description("타입"),
-                    fieldWithPath("data.title").type(JsonFieldType.STRING).description("타이틀"),
-                    fieldWithPath("data.status").type(JsonFieldType.NUMBER).description("상태 코드"),
-                    fieldWithPath("data.detail").type(JsonFieldType.STRING).description("상세 설명"),
-                    fieldWithPath("data.instance").type(JsonFieldType.STRING).description("인스턴스 URI"),
-                    fieldWithPath("data.validationError[].field").type(JsonFieldType.STRING).description("유효성 검사 실패 필드"),
-                    fieldWithPath("data.validationError[].message").type(JsonFieldType.STRING).description("유효성 검사 실패 메시지"),
-                    fieldWithPath("serverDateTime").type(JsonFieldType.STRING).description("서버 시간")
-                )
-            ));
+                        .content(objectMapper.writeValueAsString(waitingCreateRequest))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.statusCode").value("400"))
+                .andExpect(jsonPath("$.data.title").value("MethodArgumentNotValidException"))
+                .andDo(document("waiting-create-valid-null",
+                        requestFields(
+                                fieldWithPath("userId").type(JsonFieldType.VARIES).description("유저 아이디"),
+                                fieldWithPath("shopId").type(JsonFieldType.VARIES).description("매장 아이디"),
+                                fieldWithPath("adultCount").type(JsonFieldType.NUMBER).description("어른 인원 수"),
+                                fieldWithPath("childCount").type(JsonFieldType.NUMBER).description("유아 인원 수")
+                        ),
+                        responseFields(
+                                fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("상태 코드"),
+                                fieldWithPath("data.type").type(JsonFieldType.STRING).description("타입"),
+                                fieldWithPath("data.title").type(JsonFieldType.STRING).description("타이틀"),
+                                fieldWithPath("data.status").type(JsonFieldType.NUMBER).description("상태 코드"),
+                                fieldWithPath("data.detail").type(JsonFieldType.STRING).description("상세 설명"),
+                                fieldWithPath("data.instance").type(JsonFieldType.STRING).description("인스턴스 URI"),
+                                fieldWithPath("data.validationError[].field").type(JsonFieldType.STRING).description("유효성 검사 실패 필드"),
+                                fieldWithPath("data.validationError[].message").type(JsonFieldType.STRING).description("유효성 검사 실패 메시지"),
+                                fieldWithPath("serverDateTime").type(JsonFieldType.STRING).description("서버 시간")
+                        )
+                ));
     }
 
     static Stream<Arguments> provideWaitingCreateNullValue() {
         return Stream.of(
-            Arguments.arguments(new WaitingCreateRequest(null, 1L, 2, 0)),
-            Arguments.arguments(new WaitingCreateRequest(1L, null, 2, 0))
+                Arguments.arguments(new WaitingCreateRequest(null, 1L, 2, 0)),
+                Arguments.arguments(new WaitingCreateRequest(1L, null, 2, 0))
         );
+    }
+
+    @Test
+    @DisplayName("웨이팅을 취소한다.")
+    void cancelWaitingTest() throws Exception {
+        //given
+        var waitingId = 1L;
+        doNothing().when(waitingService).cancelWaiting(waitingId);
+
+        //when & then
+        mockMvc.perform(patch("/api/customer/v1/waitings/{waitingId}", waitingId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isNoContent())
+                .andExpect(jsonPath("$.statusCode").value("204"))
+                .andExpect(jsonPath("$.data").doesNotExist())
+                .andExpect(jsonPath("$.serverDateTime").exists())
+                .andDo(document("waiting-cancel",
+                        responseFields(
+                                fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("상태 코드"),
+                                fieldWithPath("data").type(JsonFieldType.NULL).description("응답 바디(비어있음)"),
+                                fieldWithPath("serverDateTime").type(JsonFieldType.STRING).description("생성된 서버 시간")
+                        )
+                ));
     }
 }


### PR DESCRIPTION
## 🖊️ 1. Changes

- 유저 웨이팅을 취소하는 엔드포인트를 구현하였습니다.
- 유저 웨이팅을 취소하는 엔드포인트에 대한 테스트를 구현하였습니다.

## 🖼️ 2. Screenshot
<img width="774" alt="image" src="https://github.com/prgrms-be-devcourse/BE-04-DevTable/assets/74203371/d0e168b5-d161-4523-8b35-b9771d73349f">


## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer
- Void 타입의 엔드 포인트 작성 시 null 값을 보내주게 됩니다. 빈 리스트를 보낼지 null 값을 보낼지 여쭈어봤는데 통일성만 있으면 될 것 같다고 말씀해주셔서, null 값으로 통일하면 될 것 같습니다.
- Void 타입의 엔드 포인트의 Restdocs에서 data에 대한 description을 통일하는게 좋을 것 같습니다. 이전에 도연님께서 `"응답 바디(비어있음)"` 을 사용하여 동일하게 사용하였습니다.
- 엔드포인트 기능 구현하면서 알았는데 index.adoc 에 반영이 안되어있더군요! 제가 추가해두겠습니당

## ✅ 5. Plans
- [ ] - 
- [ ] - 
