### PR TITLE
[MDH-24] feat : 점주 웨이팅 상태 변경 기능, 테스트 추가

### DIFF
--- a/src/main/java/com/mdh/devtable/ownerwaitng/application/OwnerWaitingService.java
+++ b/src/main/java/com/mdh/devtable/ownerwaitng/application/OwnerWaitingService.java
@@ -2,6 +2,7 @@ package com.mdh.devtable.ownerwaitng.application;
 
 import com.mdh.devtable.ownerwaitng.infra.persistence.OwnerWaitingRepository;
 import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
+import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerWaitingStatusChangeRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,8 +17,15 @@ public class OwnerWaitingService {
 
     @Transactional
     public void changeShopWaitingStatus(Long shopId, OwnerShopWaitingStatusChangeRequest request) {
-        var shopWaiting = ownerWaitingRepository.findByShopId(shopId)
+        var shopWaiting = ownerWaitingRepository.findShopWaitingByShopId(shopId)
                 .orElseThrow(() -> new NoSuchElementException("매장 웨이팅 조회 결과가 없습니다."));
         shopWaiting.changeShopWaitingStatus(request.shopWaitingStatus());
+    }
+
+    @Transactional
+    public void changeWaitingStatus(Long waitingId, OwnerWaitingStatusChangeRequest request) {
+        var waiting = ownerWaitingRepository.findWaitingByWaitingId(waitingId)
+                .orElseThrow(() -> new NoSuchElementException("웨이팅 조회 결과가 없습니다."));
+        waiting.changeWaitingStatus(request.waitingStatus());
     }
 }

--- a/src/main/java/com/mdh/devtable/ownerwaitng/infra/persistence/OwnerWaitingRepository.java
+++ b/src/main/java/com/mdh/devtable/ownerwaitng/infra/persistence/OwnerWaitingRepository.java
@@ -2,10 +2,14 @@ package com.mdh.devtable.ownerwaitng.infra.persistence;
 
 
 import com.mdh.devtable.waiting.domain.ShopWaiting;
+import com.mdh.devtable.waiting.domain.Waiting;
 
 import java.util.Optional;
 
 public interface OwnerWaitingRepository {
 
-    Optional<ShopWaiting> findByShopId(Long shopId);
+    Optional<ShopWaiting> findShopWaitingByShopId(Long shopId);
+
+    Optional<Waiting> findWaitingByWaitingId(Long waitingId);
+
 }

--- a/src/main/java/com/mdh/devtable/ownerwaitng/infra/persistence/OwnerWaitingRepositoryImpl.java
+++ b/src/main/java/com/mdh/devtable/ownerwaitng/infra/persistence/OwnerWaitingRepositoryImpl.java
@@ -1,7 +1,9 @@
 package com.mdh.devtable.ownerwaitng.infra.persistence;
 
 import com.mdh.devtable.waiting.domain.ShopWaiting;
+import com.mdh.devtable.waiting.domain.Waiting;
 import com.mdh.devtable.waiting.infra.persistence.ShopWaitingRepository;
+import com.mdh.devtable.waiting.infra.persistence.WaitingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -12,9 +14,15 @@ import java.util.Optional;
 public class OwnerWaitingRepositoryImpl implements OwnerWaitingRepository {
 
     private final ShopWaitingRepository shopWaitingRepository;
+    private final WaitingRepository waitingRepository;
 
     @Override
-    public Optional<ShopWaiting> findByShopId(Long shopId) {
+    public Optional<ShopWaiting> findShopWaitingByShopId(Long shopId) {
         return shopWaitingRepository.findById(shopId);
+    }
+
+    @Override
+    public Optional<Waiting> findWaitingByWaitingId(Long waitingId) {
+        return waitingRepository.findById(waitingId);
     }
 }


### PR DESCRIPTION
## 🖊️ 1. Changes

- 기존의 점주 웨이팅 서비스 코드 테스트를 mock 기반으로 변경했습니다.

## 🖼️ 2. Screenshot

-

## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer

- 웨이팅 상태 변경에 대한 메소드를 따로따로 분리하기 보다는 웨이팅 방문처리, 노쇼 처리, 입장 처리를 인자로 받아 변경하는 것이 더 맞다고 생각해 이렇게 작성했습니다~

## ✅ 5. Plans
- [ ] - 엔드포인트도 올릴게요~
- [ ] - 
