### PR TITLE
[MDH-48] feat : 웨이팅 상태 변경 엔드포인트, 테스트 코드 작성

### DIFF
--- a/src/main/java/com/mdh/devtable/ownerwaitng/presentaion/controller/OwnerWaitingController.java
+++ b/src/main/java/com/mdh/devtable/ownerwaitng/presentaion/controller/OwnerWaitingController.java
@@ -3,6 +3,7 @@ package com.mdh.devtable.ownerwaitng.presentaion.controller;
 import com.mdh.devtable.global.ApiResponse;
 import com.mdh.devtable.ownerwaitng.application.OwnerWaitingService;
 import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
+import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerWaitingStatusChangeRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +19,12 @@ public class OwnerWaitingController {
     @PatchMapping("/shops/{shopId}")
     public ResponseEntity<ApiResponse<Void>> changShopWaitingStatus(@RequestBody OwnerShopWaitingStatusChangeRequest request, @PathVariable("shopId") Long shopId) {
         ownerWaitingService.changeShopWaitingStatus(shopId, request);
+        return new ResponseEntity<>(ApiResponse.ok(null), HttpStatus.OK);
+    }
+
+    @PatchMapping("/waitings/{waitingId}")
+    public ResponseEntity<ApiResponse<Void>> changeWaitingStatus(@RequestBody OwnerWaitingStatusChangeRequest request, @PathVariable("waitingId") Long waitingId) {
+        ownerWaitingService.changeWaitingStatus(waitingId, request);
         return new ResponseEntity<>(ApiResponse.ok(null), HttpStatus.OK);
     }
 }

--- a/src/test/java/com/mdh/devtable/ownerwaitng/application/OwnerWaitingServiceTest.java
+++ b/src/test/java/com/mdh/devtable/ownerwaitng/application/OwnerWaitingServiceTest.java
@@ -4,7 +4,7 @@ import com.mdh.devtable.ownerwaitng.infra.persistence.OwnerWaitingRepository;
 import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
 import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerWaitingStatusChangeRequest;
 import com.mdh.devtable.waiting.domain.*;
-import org.junit.jupiter.api.Assertions;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -50,7 +50,7 @@ class OwnerWaitingServiceTest {
 
         // then
         verify(ownerWaitingRepository, times(1)).findShopWaitingByShopId(shopId);
-        Assertions.assertEquals(ShopWaitingStatus.valueOf(status), shopWaiting.getShopWaitingStatus());
+        Assertions.assertThat(ShopWaitingStatus.valueOf(status)).isEqualTo(shopWaiting.getShopWaitingStatus());
     }
 
     @DisplayName("손님의 웨이팅 상태를 변경할 수 있다.")
@@ -81,6 +81,6 @@ class OwnerWaitingServiceTest {
 
         // then
         verify(ownerWaitingRepository, times(1)).findWaitingByWaitingId(waitingId);
-        Assertions.assertEquals(WaitingStatus.valueOf(status), waiting.getWaitingStatus());
+        Assertions.assertThat(WaitingStatus.valueOf(status)).isEqualTo(waiting.getWaitingStatus());
     }
 }

--- a/src/test/java/com/mdh/devtable/ownerwaitng/presentaion/controller/OwnerWaitingControllerTest.java
+++ b/src/test/java/com/mdh/devtable/ownerwaitng/presentaion/controller/OwnerWaitingControllerTest.java
@@ -3,7 +3,9 @@ package com.mdh.devtable.ownerwaitng.presentaion.controller;
 import com.mdh.devtable.RestDocsSupport;
 import com.mdh.devtable.ownerwaitng.application.OwnerWaitingService;
 import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
+import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerWaitingStatusChangeRequest;
 import com.mdh.devtable.waiting.domain.ShopWaitingStatus;
+import com.mdh.devtable.waiting.domain.WaitingStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -76,6 +78,64 @@ class OwnerWaitingControllerTest extends RestDocsSupport {
                 .andDo(document("user-sign-up-invalid-password",
                         requestFields(
                                 fieldWithPath("shopWaitingStatus").type(JsonFieldType.STRING).description("매장 상태")
+                        ),
+                        responseFields(
+                                fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("상태 코드"),
+                                fieldWithPath("data.type").type(JsonFieldType.STRING).description("타입"),
+                                fieldWithPath("data.title").type(JsonFieldType.STRING).description("타이틀"),
+                                fieldWithPath("data.status").type(JsonFieldType.NUMBER).description("상태 코드"),
+                                fieldWithPath("data.detail").type(JsonFieldType.STRING).description("상세 설명"),
+                                fieldWithPath("data.instance").type(JsonFieldType.STRING).description("인스턴스 URI"),
+                                fieldWithPath("serverDateTime").type(JsonFieldType.STRING).description("서버 시간")
+                        )
+                ));
+    }
+
+    @DisplayName("매장의 웨이팅 상태를 변경할 수 있다.")
+    @Test
+    void changWaitingStatus() throws Exception {
+        //given
+        var waitingId = 1L;
+        var request = new OwnerWaitingStatusChangeRequest(WaitingStatus.VISITED);
+        doNothing().when(ownerWaitingService).changeWaitingStatus(waitingId, request);
+
+        //when & then
+        mockMvc.perform(patch("/api/owner/v1/waitings/" + waitingId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value("200"))
+                .andExpect(jsonPath("$.data").doesNotExist())
+                .andExpect(jsonPath("$.serverDateTime").exists())
+                .andDo(document("owner-shops-waiting",
+                        requestFields(
+                                fieldWithPath("waitingStatus").type(JsonFieldType.STRING).description("웨이팅 상태")
+                        ),
+                        responseFields(fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("상태 코드"),
+                                fieldWithPath("data").type(JsonFieldType.NULL).description("응답 바디(비어있음)"),
+                                fieldWithPath("serverDateTime").type(JsonFieldType.STRING).description("변경된 서버 시간")
+                        )
+                ));
+    }
+
+    @DisplayName("매장의 웨이팅 상태를 잘못된 형태로 변경할 수 없다.")
+    @Test
+    void changWaitingStatusThrowException() throws Exception {
+        //given
+        var waitingId = 1L;
+        var request = new HashMap<String, String>();
+        request.put("waitingStatus", "asf");
+
+        //when & then
+        mockMvc.perform(patch("/api/owner/v1/waitings/" + waitingId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.statusCode").value("400"))
+                .andExpect(jsonPath("$.data.title").value("HttpMessageNotReadableException"))
+                .andDo(document("user-sign-up-invalid-password",
+                        requestFields(
+                                fieldWithPath("waitingStatus").type(JsonFieldType.STRING).description("웨이팅 상태")
                         ),
                         responseFields(
                                 fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("상태 코드"),


### PR DESCRIPTION
## 🖊️ 1. Changes

- 웨이팅 상태 변경 엔드포인트, 테스트 코드를 작성했습니다.
- 이전에 피드백 받았던 JUnit 테스트를 AssertJ 기반으로 변경했습니다.

## 🖼️ 2. Screenshot

-

## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer

- OwnerWaitingStatusChangeRequest클래스를 제가 옛날 커밋에서 추가했는지 변경사항에 잡히지가 않네요 아래는 해당 클래스 입니다.
```
package com.mdh.devtable.ownerwaitng.presentaion.dto;

import com.mdh.devtable.waiting.domain.WaitingStatus;

public record OwnerWaitingStatusChangeRequest(
        WaitingStatus waitingStatus
) {
}
```

## ✅ 5. Plans
- [ ] - 
- [ ] - 
