### PR TITLE
[MDH-56] 유저는 상태별로 자신의 웨이팅을 조회 할 수 있다.

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -42,3 +42,7 @@ operation::waiting-create-valid-null[snippets = 'http-request,http-response,requ
 == Waiting 취소
 
 operation::waiting-cancel[snippets = 'http-request,http-response,request-body,response-fields']
+
+== 유저 개인의 웨이팅 조회
+
+operation::find-my-waitings[snippets = 'http-request,http-response,request-body,response-fields']

--- a/src/main/java/com/mdh/devtable/shop/ShopType.java
+++ b/src/main/java/com/mdh/devtable/shop/ShopType.java
@@ -1,7 +1,9 @@
 package com.mdh.devtable.shop;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @RequiredArgsConstructor
 public enum ShopType {
     KOREAN("한식"),

--- a/src/main/java/com/mdh/devtable/waiting/application/WaitingService.java
+++ b/src/main/java/com/mdh/devtable/waiting/application/WaitingService.java
@@ -1,16 +1,20 @@
 package com.mdh.devtable.waiting.application;
 
+import com.mdh.devtable.waiting.application.dto.UserWaitingResponse;
 import com.mdh.devtable.waiting.domain.Waiting;
 import com.mdh.devtable.waiting.domain.WaitingPeople;
 import com.mdh.devtable.waiting.domain.WaitingStatus;
 import com.mdh.devtable.waiting.infra.persistence.ShopWaitingRepository;
 import com.mdh.devtable.waiting.infra.persistence.WaitingLine;
 import com.mdh.devtable.waiting.infra.persistence.WaitingRepository;
+import com.mdh.devtable.waiting.infra.persistence.dto.UserWaitingQueryDto;
+import com.mdh.devtable.waiting.presentation.dto.MyWaitingsRequest;
 import com.mdh.devtable.waiting.presentation.dto.WaitingCreateRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 
 @Service
@@ -59,6 +63,15 @@ public class WaitingService {
         var shopId = waiting.getShopWaiting().getShopId();
         waitingLine.cancel(shopId, waitingId, waiting.getCreatedDate());
         waiting.changeWaitingStatus(WaitingStatus.CANCEL);
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserWaitingResponse> findAllByUserIdAndStatus(MyWaitingsRequest request) {
+
+        return waitingRepository.findAllByUserIdAndWaitingStatus(request.userId(), request.waitingStatus())
+                .stream()
+                .map(UserWaitingQueryDto::toUserWaitingResponse)
+                .toList();
     }
 
     private void saveWaitingLine(Long shopId, Waiting savedWaiting) {

--- a/src/main/java/com/mdh/devtable/waiting/application/dto/UserWaitingResponse.java
+++ b/src/main/java/com/mdh/devtable/waiting/application/dto/UserWaitingResponse.java
@@ -1,0 +1,12 @@
+package com.mdh.devtable.waiting.application.dto;
+
+public record UserWaitingResponse(
+        Long shopId,
+        Long waitingId,
+        String shopName,
+        String shopType,
+        String region,
+        int waitingNumber,
+        int waitingCount
+) {
+}

--- a/src/main/java/com/mdh/devtable/waiting/application/dto/WaitingResponse.java
+++ b/src/main/java/com/mdh/devtable/waiting/application/dto/WaitingResponse.java
@@ -1,0 +1,4 @@
+package com.mdh.devtable.waiting.application.dto;
+
+public record WaitingResponse() {
+}

--- a/src/main/java/com/mdh/devtable/waiting/domain/ShopWaiting.java
+++ b/src/main/java/com/mdh/devtable/waiting/domain/ShopWaiting.java
@@ -49,7 +49,7 @@ public class ShopWaiting extends BaseTimeEntity {
         this.waitingCount = 0;
         this.maximumWaiting = maximumWaiting;
         this.shopWaitingStatus = ShopWaitingStatus.CLOSE;
-        this.childEnabled = false;
+        this.childEnabled = true;
         this.minimumWaitingPeople = minimumWaitingPeople;
         this.maximumWaitingPeople = maximumWaitingPeople;
     }

--- a/src/main/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepository.java
+++ b/src/main/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepository.java
@@ -1,14 +1,25 @@
 package com.mdh.devtable.waiting.infra.persistence;
 
 import com.mdh.devtable.waiting.domain.Waiting;
+import com.mdh.devtable.waiting.domain.WaitingStatus;
+import com.mdh.devtable.waiting.infra.persistence.dto.UserWaitingQueryDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface WaitingRepository extends JpaRepository<Waiting, Long> {
 
     @Query("select w from Waiting w where w.waitingStatus = 'PROGRESS' and w.userId = :userId")
     Optional<Waiting> findByProgressWaiting(@Param("userId") Long userId);
+
+    @Query("""
+             select new com.mdh.devtable.waiting.infra.persistence.dto.UserWaitingQueryDto(s.id, w.id, s.name, s.shopType, s.region.city, s.region.district, w.waitingNumber, w.waitingPeople.adultCount, w.waitingPeople.childCount)
+             from Waiting w
+             join Shop s on w.shopWaiting.shopId = s.id
+             where w.userId = :userId and w.waitingStatus = :waitingStatus
+            """)
+    List<UserWaitingQueryDto> findAllByUserIdAndWaitingStatus(@Param("userId") Long userId, @Param("waitingStatus") WaitingStatus waitingStatus);
 }

--- a/src/main/java/com/mdh/devtable/waiting/infra/persistence/dto/UserWaitingQueryDto.java
+++ b/src/main/java/com/mdh/devtable/waiting/infra/persistence/dto/UserWaitingQueryDto.java
@@ -1,0 +1,38 @@
+package com.mdh.devtable.waiting.infra.persistence.dto;
+
+import com.mdh.devtable.shop.ShopType;
+import com.mdh.devtable.waiting.application.dto.UserWaitingResponse;
+
+public record UserWaitingQueryDto(
+        Long shopId,
+        Long waitingId,
+        String shopName,
+        ShopType shopType,
+        String city,
+        String district,
+        int waitingNumber,
+        int adultCount,
+        int childCount
+) {
+
+    public UserWaitingResponse toUserWaitingResponse() {
+        return new UserWaitingResponse(
+                shopId,
+                waitingId,
+                shopName,
+                shopType.getName(),
+                fieldToRegion(),
+                waitingNumber,
+                adultCount + childCount
+        );
+    }
+
+    private String fieldToRegion() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(city)
+                .append(" ")
+                .append(district);
+
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/mdh/devtable/waiting/presentation/UserWaitingController.java
+++ b/src/main/java/com/mdh/devtable/waiting/presentation/UserWaitingController.java
@@ -2,6 +2,8 @@ package com.mdh.devtable.waiting.presentation;
 
 import com.mdh.devtable.global.ApiResponse;
 import com.mdh.devtable.waiting.application.WaitingService;
+import com.mdh.devtable.waiting.application.dto.UserWaitingResponse;
+import com.mdh.devtable.waiting.presentation.dto.MyWaitingsRequest;
 import com.mdh.devtable.waiting.presentation.dto.WaitingCreateRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/customer/v1/waitings")
@@ -17,6 +20,12 @@ import java.net.URI;
 public class UserWaitingController {
 
     private final WaitingService waitingService;
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<ApiResponse<List<UserWaitingResponse>>> findWaitingsByUserIdAndStatus(@RequestBody @Valid MyWaitingsRequest request) {
+        var findUserWaitings = waitingService.findAllByUserIdAndStatus(request);
+        return ResponseEntity.ok(ApiResponse.ok(findUserWaitings));
+    }
 
     @PostMapping
     public ResponseEntity<ApiResponse<URI>> createWaiting(@RequestBody @Valid WaitingCreateRequest waitingCreateRequest) {

--- a/src/main/java/com/mdh/devtable/waiting/presentation/dto/MyWaitingsRequest.java
+++ b/src/main/java/com/mdh/devtable/waiting/presentation/dto/MyWaitingsRequest.java
@@ -1,0 +1,11 @@
+package com.mdh.devtable.waiting.presentation.dto;
+
+import com.mdh.devtable.waiting.domain.WaitingStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record MyWaitingsRequest(
+        @NotNull(message = "userId는 null 일 수 없습니다.")
+        Long userId,
+        WaitingStatus waitingStatus
+) {
+}

--- a/src/main/java/com/mdh/devtable/waiting/presentation/dto/MyWaitingsRequest.java
+++ b/src/main/java/com/mdh/devtable/waiting/presentation/dto/MyWaitingsRequest.java
@@ -4,8 +4,10 @@ import com.mdh.devtable.waiting.domain.WaitingStatus;
 import jakarta.validation.constraints.NotNull;
 
 public record MyWaitingsRequest(
+
         @NotNull(message = "userId는 null 일 수 없습니다.")
         Long userId,
+
         WaitingStatus waitingStatus
 ) {
 }

--- a/src/test/java/com/mdh/devtable/waiting/WaitingTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/WaitingTest.java
@@ -1,10 +1,6 @@
 package com.mdh.devtable.waiting;
 
-import com.mdh.devtable.waiting.domain.ShopWaiting;
-import com.mdh.devtable.waiting.domain.ShopWaitingStatus;
-import com.mdh.devtable.waiting.domain.Waiting;
-import com.mdh.devtable.waiting.domain.WaitingPeople;
-import com.mdh.devtable.waiting.domain.WaitingStatus;
+import com.mdh.devtable.waiting.domain.*;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,39 +28,39 @@ class WaitingTest {
         var maximumWaitingPeople = 5;
 
         var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .minimumWaitingPeople(minimumWaitingPeople)
+                .maximumWaitingPeople(maximumWaitingPeople)
+                .build();
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
 
         //when
         var waiting = Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .userId(userId)
-            .waitingPeople(waitingPeople)
-            .build();
+                .shopWaiting(shopWaiting)
+                .userId(userId)
+                .waitingPeople(waitingPeople)
+                .build();
 
         //then
         assertThat(waiting)
-            .extracting(Waiting::getWaitingPeople,
-                Waiting::getShopWaiting,
-                Waiting::getUserId,
-                Waiting::getWaitingStatus,
-                Waiting::getPostponedCount)
-            .containsExactly(waitingPeople,
-                shopWaiting,
-                userId,
-                WaitingStatus.PROGRESS,
-                0);
+                .extracting(Waiting::getWaitingPeople,
+                        Waiting::getShopWaiting,
+                        Waiting::getUserId,
+                        Waiting::getWaitingStatus,
+                        Waiting::getPostponedCount)
+                .containsExactly(waitingPeople,
+                        shopWaiting,
+                        userId,
+                        WaitingStatus.PROGRESS,
+                        0);
     }
 
     static Stream<Arguments> waitingPeople() {
         return Stream.of(
-            Arguments.arguments(new WaitingPeople(2, 0)),
-            Arguments.arguments(new WaitingPeople(5, 0))
+                Arguments.arguments(new WaitingPeople(2, 0)),
+                Arguments.arguments(new WaitingPeople(5, 0))
         );
     }
 
@@ -80,11 +76,11 @@ class WaitingTest {
         var maximumWaitingPeople = 5;
 
         var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .minimumWaitingPeople(minimumWaitingPeople)
+                .maximumWaitingPeople(maximumWaitingPeople)
+                .build();
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
         shopWaiting.changeShopWaitingStatus(waitingStatus);
@@ -93,12 +89,12 @@ class WaitingTest {
 
         //when & then
         assertThatThrownBy(() -> Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .userId(userId)
-            .waitingPeople(waitingPeople)
-            .build())
-            .isInstanceOf(IllegalStateException.class)
-            .hasMessage("매장이 오픈 상태가 아니면 웨이팅을 등록 할 수 없습니다.");
+                .shopWaiting(shopWaiting)
+                .userId(userId)
+                .waitingPeople(waitingPeople)
+                .build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("매장이 오픈 상태가 아니면 웨이팅을 등록 할 수 없습니다.");
     }
 
     @Test
@@ -112,21 +108,21 @@ class WaitingTest {
         var maximumWaitingPeople = 5;
 
         var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .minimumWaitingPeople(minimumWaitingPeople)
+                .maximumWaitingPeople(maximumWaitingPeople)
+                .build();
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
 
         var waitingPeople = new WaitingPeople(2, 0);
 
         var waiting = Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .userId(userId)
-            .waitingPeople(waitingPeople)
-            .build();
+                .shopWaiting(shopWaiting)
+                .userId(userId)
+                .waitingPeople(waitingPeople)
+                .build();
         //when
         waiting.addPostponedCount();
 
@@ -147,29 +143,29 @@ class WaitingTest {
         var maximumWaitingPeople = 5;
 
         var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .minimumWaitingPeople(minimumWaitingPeople)
+                .maximumWaitingPeople(maximumWaitingPeople)
+                .build();
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
 
         var waitingPeople = new WaitingPeople(2, 0);
 
         var waiting = Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .userId(userId)
-            .waitingPeople(waitingPeople)
-            .build();
+                .shopWaiting(shopWaiting)
+                .userId(userId)
+                .waitingPeople(waitingPeople)
+                .build();
 
         //when
         waiting.changeWaitingStatus(waitingStatus);
 
         //then
         Assertions.assertThatThrownBy(waiting::addPostponedCount)
-            .isInstanceOf(IllegalStateException.class)
-            .hasMessage("진행 상태가 아닌 웨이팅 미루기는 불가능 합니다.");
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("진행 상태가 아닌 웨이팅 미루기는 불가능 합니다.");
     }
 
     @Test
@@ -183,21 +179,21 @@ class WaitingTest {
         var maximumWaitingPeople = 5;
 
         var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .minimumWaitingPeople(minimumWaitingPeople)
+                .maximumWaitingPeople(maximumWaitingPeople)
+                .build();
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
 
         var waitingPeople = new WaitingPeople(2, 0);
 
         var waiting = Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .userId(userId)
-            .waitingPeople(waitingPeople)
-            .build();
+                .shopWaiting(shopWaiting)
+                .userId(userId)
+                .waitingPeople(waitingPeople)
+                .build();
 
         //when
         waiting.addPostponedCount();
@@ -205,8 +201,8 @@ class WaitingTest {
 
         //then
         Assertions.assertThatThrownBy(waiting::addPostponedCount)
-            .isInstanceOf(IllegalStateException.class)
-            .hasMessage("웨이팅 미루기는 2회 초과하여 불가능 합니다.");
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("웨이팅 미루기는 2회 초과하여 불가능 합니다.");
     }
 
     @ParameterizedTest
@@ -221,21 +217,21 @@ class WaitingTest {
         var maximumWaitingPeople = 5;
 
         var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .minimumWaitingPeople(minimumWaitingPeople)
+                .maximumWaitingPeople(maximumWaitingPeople)
+                .build();
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
 
         var waitingPeople = new WaitingPeople(2, 0);
 
         var waiting = Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .userId(userId)
-            .waitingPeople(waitingPeople)
-            .build();
+                .shopWaiting(shopWaiting)
+                .userId(userId)
+                .waitingPeople(waitingPeople)
+                .build();
 
         //when
         waiting.changeWaitingStatus(waitingStatus);
@@ -256,29 +252,29 @@ class WaitingTest {
         var maximumWaitingPeople = 5;
 
         var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .minimumWaitingPeople(minimumWaitingPeople)
+                .maximumWaitingPeople(maximumWaitingPeople)
+                .build();
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
 
         var waitingPeople = new WaitingPeople(2, 0);
 
         var waiting = Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .userId(userId)
-            .waitingPeople(waitingPeople)
-            .build();
+                .shopWaiting(shopWaiting)
+                .userId(userId)
+                .waitingPeople(waitingPeople)
+                .build();
 
         //when
         waiting.changeWaitingStatus(waitingStatus);
 
         //then
         assertThatThrownBy(() -> waiting.changeWaitingStatus(WaitingStatus.PROGRESS))
-            .isInstanceOf(IllegalStateException.class)
-            .hasMessage("진행 상태가 아니면 상태 변경이 불가능 합니다.");
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("진행 상태가 아니면 상태 변경이 불가능 합니다.");
     }
 
     @ParameterizedTest
@@ -292,28 +288,28 @@ class WaitingTest {
         var maximumWaitingPeople = 5;
 
         var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .minimumWaitingPeople(minimumWaitingPeople)
+                .maximumWaitingPeople(maximumWaitingPeople)
+                .build();
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
 
         //when&then
         assertThatThrownBy(() -> Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .waitingPeople(waitingPeople)
-            .userId(1L)
-            .build())
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage(exceptionMessage);
+                .shopWaiting(shopWaiting)
+                .waitingPeople(waitingPeople)
+                .userId(1L)
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(exceptionMessage);
     }
 
     static Stream<Arguments> waitingPeopleAndExceptionMessage() {
         return Stream.of(
-            Arguments.arguments(new WaitingPeople(1, 0), "웨이팅 인원은 2명 이상이어야 합니다."),
-            Arguments.arguments(new WaitingPeople(6, 0), "웨이팅 인원은 5명 이하여야 합니다.")
+                Arguments.arguments(new WaitingPeople(1, 0), "웨이팅 인원은 2명 이상이어야 합니다."),
+                Arguments.arguments(new WaitingPeople(6, 0), "웨이팅 인원은 5명 이하여야 합니다.")
         );
     }
 
@@ -327,21 +323,22 @@ class WaitingTest {
         var maximumWaitingPeople = 5;
 
         var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .minimumWaitingPeople(minimumWaitingPeople)
+                .maximumWaitingPeople(maximumWaitingPeople)
+                .build();
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
+        shopWaiting.updateChildEnabled(false);
 
         //when & then
         assertThatThrownBy(() -> Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .waitingPeople(new WaitingPeople(2, 2))
-            .build())
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("유아 손님 입장이 불가능한 매장입니다.");
+                .shopWaiting(shopWaiting)
+                .waitingPeople(new WaitingPeople(2, 2))
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("유아 손님 입장이 불가능한 매장입니다.");
     }
 
     @Test
@@ -354,20 +351,20 @@ class WaitingTest {
         var maximumWaitingPeople = 5;
 
         var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .minimumWaitingPeople(minimumWaitingPeople)
+                .maximumWaitingPeople(maximumWaitingPeople)
+                .build();
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
         shopWaiting.updateChildEnabled(true);
 
         //when
         var waiting = Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .waitingPeople(new WaitingPeople(2, 2))
-            .build();
+                .shopWaiting(shopWaiting)
+                .waitingPeople(new WaitingPeople(2, 2))
+                .build();
 
         //then
         assertThat(waiting).isNotNull();

--- a/src/test/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepositoryTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepositoryTest.java
@@ -15,7 +15,6 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
@@ -23,7 +22,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 @DataJpaTest
 @Import({JpaConfig.class})
 @ActiveProfiles("test")
-@TestPropertySource(locations = "classpath:application-test.yml")
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class WaitingRepositoryTest {
 

--- a/src/test/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepositoryTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepositoryTest.java
@@ -1,0 +1,85 @@
+package com.mdh.devtable.waiting.infra.persistence;
+
+import com.mdh.devtable.DataInitializerFactory;
+import com.mdh.devtable.global.config.JpaConfig;
+import com.mdh.devtable.shop.infra.persistence.RegionRepository;
+import com.mdh.devtable.shop.infra.persistence.ShopRepository;
+import com.mdh.devtable.user.infra.persistence.UserRepository;
+import com.mdh.devtable.waiting.domain.ShopWaitingStatus;
+import com.mdh.devtable.waiting.domain.WaitingStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+
+@DataJpaTest
+@Import({JpaConfig.class})
+@ActiveProfiles("test")
+@TestPropertySource(locations = "classpath:application-test.yml")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class WaitingRepositoryTest {
+
+    @Autowired
+    private WaitingRepository waitingRepository;
+
+    @Autowired
+    private RegionRepository regionRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ShopWaitingRepository shopWaitingRepository;
+
+    @Autowired
+    private ShopRepository shopRepository;
+
+    @ParameterizedTest
+    @ValueSource(strings = {"PROGRESS", "CANCEL", "NO_SHOW", "VISITED"})
+    @DisplayName("유저의 웨이팅 목록을 상태별로 조회 할 수 있다.")
+    void findAllByUserIdAndWaitingStatus(String waitingStatus) {
+        //given
+        var owner = DataInitializerFactory.owner();
+        userRepository.save(owner);
+
+        //매장 정보 생성
+        var region = DataInitializerFactory.region();
+        regionRepository.save(region);
+
+        var shopAddress = DataInitializerFactory.shopAddress();
+        var shopDetails = DataInitializerFactory.shopDetails();
+
+        var shop = DataInitializerFactory.shop(owner.getId(), shopDetails, region, shopAddress);
+        shopRepository.save(shop);
+
+        var shopWaiting = DataInitializerFactory.shopWaiting(shop.getId(), 30, 8, 2);
+        shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
+        shopWaitingRepository.save(shopWaiting);
+
+        //웨이팅 등록
+        var guest = DataInitializerFactory.guest();
+        userRepository.save(guest);
+
+        var waitingPeople = DataInitializerFactory.waitingPeople(2, 3);
+        var waiting = DataInitializerFactory.waiting(guest.getId(), shopWaiting, waitingPeople);
+
+        waiting.changeWaitingStatus(WaitingStatus.valueOf(waitingStatus));
+        waitingRepository.save(waiting);
+
+        //when
+        var findUserWaitings = waitingRepository.findAllByUserIdAndWaitingStatus(guest.getId(), WaitingStatus.valueOf(waitingStatus));
+
+        //then
+        assertThat(findUserWaitings).hasSize(1);
+        assertThat(findUserWaitings).extracting("shopId", "waitingId")
+                .contains(tuple(shop.getId(), waiting.getId()));
+    }
+}


### PR DESCRIPTION
## 🖊️ 1. Changes
- 유저의 웨이팅 목록을 필터 별로 조회하는 쿼리를 추가하였습니다.
- 매장 웨이팅의 키즈 존 여부에 대한 기본 값을 false에서 true로 변경하였습니다.
- 유저의 웨이팅 목록을 상태별로 조회하는 쿼리를 테스트 하였습니다.
- 유저의 웨이팅 목록을 상태별로 조회하는 엔드포인트를 구현하고, 이에 대한 테스트를 작성하였습니다.

## 🖼️ 2. Screenshot
<img width="508" alt="image" src="https://github.com/prgrms-be-devcourse/BE-04-DevTable/assets/74203371/fb2f6f9d-d3fa-4d85-ad66-2819f9f7b4a9">


## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer
- 매장 웨이팅의 키즈 존의 기본 값을 false에서 true로 변경하였습니다. 음식점에서 키즈 존이 아닌 경우가 흔치 않을 것이라고 판단했습니다!
- ShopType에 Getter가 없어서 enum 타입에 대한 필드 값을 불러오지 못하여 Getter를 추가하였습니다.
- Query문이 길어서 JDK 15에 도입 된 텍스트 블록을 사용하였습니다.

## ✅ 5. Plans
- [x] - 서비스 테스트 코드의 대대적인 수정으로 머지 이후에 서비스 테스트 코드를 작성 할 예정입니다.
- [X] - Github Action에서 Repository 테스트 진행 중 PropertySource를 찾을 수 없다는 예외가 발생하여 제거하여 테스트 중입니다.
