### PR TITLE
[MDH-16] 웨이팅 상세 조회

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,14 +35,14 @@
 # When using Gradle or Maven with auto-import, you should exclude module files,
 # since they will be recreated, and may cause churn.  Uncomment if using
 # auto-import.
-# .idea/artifacts
-# .idea/compiler.xml
-# .idea/jarRepositories.xml
-# .idea/modules.xml
-# .idea/*.iml
-# .idea/modules
-# *.iml
-# *.ipr
+.idea/artifacts
+.idea/compiler.xml
+.idea/jarRepositories.xml
+.idea/modules.xml
+.idea/*.iml
+.idea/modules
+*.iml
+*.ipr
 
 # CMake
 cmake-build-*/
@@ -207,6 +207,3 @@ gradle-app.setting
 ### SCHEMA ###
 *.sql
 # End of https://www.toptal.com/developers/gitignore/api/intellij,macos,java,gradle
-
-### .idea ###
-.idea/

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+devtable

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$" />
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK" />
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -45,4 +45,4 @@ operation::waiting-cancel[snippets = 'http-request,http-response,request-body,re
 
 == Waiting 상세 조회
 
-operation::waiting-de[snippets = 'http-request,http-response,request-body,response-fields']
+operation::waiting-detail-find[snippets = 'http-request,http-response,request-body,response-fields']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -42,3 +42,7 @@ operation::waiting-create-valid-null[snippets = 'http-request,http-response,requ
 == Waiting 취소
 
 operation::waiting-cancel[snippets = 'http-request,http-response,request-body,response-fields']
+
+== Waiting 상세 조회
+
+operation::waiting-de[snippets = 'http-request,http-response,request-body,response-fields']

--- a/src/main/java/com/mdh/devtable/ownerwaiting/application/OwnerWaitingService.java
+++ b/src/main/java/com/mdh/devtable/ownerwaiting/application/OwnerWaitingService.java
@@ -1,8 +1,8 @@
-package com.mdh.devtable.ownerwaitng.application;
+package com.mdh.devtable.ownerwaiting.application;
 
-import com.mdh.devtable.ownerwaitng.infra.persistence.OwnerWaitingRepository;
-import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
-import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerWaitingStatusChangeRequest;
+import com.mdh.devtable.ownerwaiting.infra.persistence.OwnerWaitingRepository;
+import com.mdh.devtable.ownerwaiting.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
+import com.mdh.devtable.ownerwaiting.presentaion.dto.OwnerWaitingStatusChangeRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/mdh/devtable/ownerwaiting/infra/persistence/OwnerWaitingRepository.java
+++ b/src/main/java/com/mdh/devtable/ownerwaiting/infra/persistence/OwnerWaitingRepository.java
@@ -1,4 +1,4 @@
-package com.mdh.devtable.ownerwaitng.infra.persistence;
+package com.mdh.devtable.ownerwaiting.infra.persistence;
 
 
 import com.mdh.devtable.waiting.domain.ShopWaiting;

--- a/src/main/java/com/mdh/devtable/ownerwaiting/infra/persistence/OwnerWaitingRepositoryImpl.java
+++ b/src/main/java/com/mdh/devtable/ownerwaiting/infra/persistence/OwnerWaitingRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.mdh.devtable.ownerwaitng.infra.persistence;
+package com.mdh.devtable.ownerwaiting.infra.persistence;
 
 import com.mdh.devtable.waiting.domain.ShopWaiting;
 import com.mdh.devtable.waiting.domain.Waiting;

--- a/src/main/java/com/mdh/devtable/ownerwaiting/presentaion/controller/OwnerWaitingController.java
+++ b/src/main/java/com/mdh/devtable/ownerwaiting/presentaion/controller/OwnerWaitingController.java
@@ -1,9 +1,9 @@
-package com.mdh.devtable.ownerwaitng.presentaion.controller;
+package com.mdh.devtable.ownerwaiting.presentaion.controller;
 
 import com.mdh.devtable.global.ApiResponse;
-import com.mdh.devtable.ownerwaitng.application.OwnerWaitingService;
-import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
-import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerWaitingStatusChangeRequest;
+import com.mdh.devtable.ownerwaiting.application.OwnerWaitingService;
+import com.mdh.devtable.ownerwaiting.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
+import com.mdh.devtable.ownerwaiting.presentaion.dto.OwnerWaitingStatusChangeRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/mdh/devtable/ownerwaiting/presentaion/dto/OwnerShopWaitingStatusChangeRequest.java
+++ b/src/main/java/com/mdh/devtable/ownerwaiting/presentaion/dto/OwnerShopWaitingStatusChangeRequest.java
@@ -1,4 +1,4 @@
-package com.mdh.devtable.ownerwaitng.presentaion.dto;
+package com.mdh.devtable.ownerwaiting.presentaion.dto;
 
 import com.mdh.devtable.waiting.domain.ShopWaitingStatus;
 

--- a/src/main/java/com/mdh/devtable/ownerwaiting/presentaion/dto/OwnerWaitingStatusChangeRequest.java
+++ b/src/main/java/com/mdh/devtable/ownerwaiting/presentaion/dto/OwnerWaitingStatusChangeRequest.java
@@ -1,4 +1,4 @@
-package com.mdh.devtable.ownerwaitng.presentaion.dto;
+package com.mdh.devtable.ownerwaiting.presentaion.dto;
 
 import com.mdh.devtable.waiting.domain.WaitingStatus;
 

--- a/src/main/java/com/mdh/devtable/ownerwaitng/application/OwnerWaitingService.java
+++ b/src/main/java/com/mdh/devtable/ownerwaitng/application/OwnerWaitingService.java
@@ -2,6 +2,7 @@ package com.mdh.devtable.ownerwaitng.application;
 
 import com.mdh.devtable.ownerwaitng.infra.persistence.OwnerWaitingRepository;
 import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
+import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerWaitingStatusChangeRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,8 +17,15 @@ public class OwnerWaitingService {
 
     @Transactional
     public void changeShopWaitingStatus(Long shopId, OwnerShopWaitingStatusChangeRequest request) {
-        var shopWaiting = ownerWaitingRepository.findByShopId(shopId)
+        var shopWaiting = ownerWaitingRepository.findShopWaitingByShopId(shopId)
                 .orElseThrow(() -> new NoSuchElementException("매장 웨이팅 조회 결과가 없습니다."));
         shopWaiting.changeShopWaitingStatus(request.shopWaitingStatus());
+    }
+
+    @Transactional
+    public void changeWaitingStatus(Long waitingId, OwnerWaitingStatusChangeRequest request) {
+        var waiting = ownerWaitingRepository.findWaitingByWaitingId(waitingId)
+                .orElseThrow(() -> new NoSuchElementException("웨이팅 조회 결과가 없습니다."));
+        waiting.changeWaitingStatus(request.waitingStatus());
     }
 }

--- a/src/main/java/com/mdh/devtable/ownerwaitng/infra/persistence/OwnerWaitingRepository.java
+++ b/src/main/java/com/mdh/devtable/ownerwaitng/infra/persistence/OwnerWaitingRepository.java
@@ -2,10 +2,14 @@ package com.mdh.devtable.ownerwaitng.infra.persistence;
 
 
 import com.mdh.devtable.waiting.domain.ShopWaiting;
+import com.mdh.devtable.waiting.domain.Waiting;
 
 import java.util.Optional;
 
 public interface OwnerWaitingRepository {
 
-    Optional<ShopWaiting> findByShopId(Long shopId);
+    Optional<ShopWaiting> findShopWaitingByShopId(Long shopId);
+
+    Optional<Waiting> findWaitingByWaitingId(Long waitingId);
+
 }

--- a/src/main/java/com/mdh/devtable/ownerwaitng/infra/persistence/OwnerWaitingRepositoryImpl.java
+++ b/src/main/java/com/mdh/devtable/ownerwaitng/infra/persistence/OwnerWaitingRepositoryImpl.java
@@ -1,7 +1,9 @@
 package com.mdh.devtable.ownerwaitng.infra.persistence;
 
 import com.mdh.devtable.waiting.domain.ShopWaiting;
+import com.mdh.devtable.waiting.domain.Waiting;
 import com.mdh.devtable.waiting.infra.persistence.ShopWaitingRepository;
+import com.mdh.devtable.waiting.infra.persistence.WaitingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -12,9 +14,15 @@ import java.util.Optional;
 public class OwnerWaitingRepositoryImpl implements OwnerWaitingRepository {
 
     private final ShopWaitingRepository shopWaitingRepository;
+    private final WaitingRepository waitingRepository;
 
     @Override
-    public Optional<ShopWaiting> findByShopId(Long shopId) {
+    public Optional<ShopWaiting> findShopWaitingByShopId(Long shopId) {
         return shopWaitingRepository.findById(shopId);
+    }
+
+    @Override
+    public Optional<Waiting> findWaitingByWaitingId(Long waitingId) {
+        return waitingRepository.findById(waitingId);
     }
 }

--- a/src/main/java/com/mdh/devtable/ownerwaitng/presentaion/controller/OwnerWaitingController.java
+++ b/src/main/java/com/mdh/devtable/ownerwaitng/presentaion/controller/OwnerWaitingController.java
@@ -3,6 +3,7 @@ package com.mdh.devtable.ownerwaitng.presentaion.controller;
 import com.mdh.devtable.global.ApiResponse;
 import com.mdh.devtable.ownerwaitng.application.OwnerWaitingService;
 import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
+import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerWaitingStatusChangeRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,6 +19,12 @@ public class OwnerWaitingController {
     @PatchMapping("/shops/{shopId}")
     public ResponseEntity<ApiResponse<Void>> changShopWaitingStatus(@RequestBody OwnerShopWaitingStatusChangeRequest request, @PathVariable("shopId") Long shopId) {
         ownerWaitingService.changeShopWaitingStatus(shopId, request);
+        return new ResponseEntity<>(ApiResponse.ok(null), HttpStatus.OK);
+    }
+
+    @PatchMapping("/waitings/{waitingId}")
+    public ResponseEntity<ApiResponse<Void>> changeWaitingStatus(@RequestBody OwnerWaitingStatusChangeRequest request, @PathVariable("waitingId") Long waitingId) {
+        ownerWaitingService.changeWaitingStatus(waitingId, request);
         return new ResponseEntity<>(ApiResponse.ok(null), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/mdh/devtable/waiting/application/WaitingService.java
+++ b/src/main/java/com/mdh/devtable/waiting/application/WaitingService.java
@@ -30,7 +30,7 @@ public class WaitingService {
         var shopId = waitingDetails.shopId();
         var createdDate = waitingDetails.createdDate();
 
-        if (waitingDetails.waitingStatus() == WaitingStatus.PROGRESS) {
+        if (waitingDetails.waitingStatus().isProgress()) {
             var rank = waitingLine.findRank(shopId, waitingId, createdDate);
             return waitingDetails.toWaitingDetailsResponse(rank);
         }

--- a/src/main/java/com/mdh/devtable/waiting/application/dto/ShopWaitingResponse.java
+++ b/src/main/java/com/mdh/devtable/waiting/application/dto/ShopWaitingResponse.java
@@ -1,0 +1,12 @@
+package com.mdh.devtable.waiting.application.dto;
+
+import com.mdh.devtable.shop.ShopDetails;
+import com.mdh.devtable.shop.ShopType;
+
+public record ShopWaitingResponse(
+        String shopName,
+        ShopType shopType,
+        String region,
+        ShopDetails shopDetails
+) {
+}

--- a/src/main/java/com/mdh/devtable/waiting/application/dto/WaitingDetailsResponse.java
+++ b/src/main/java/com/mdh/devtable/waiting/application/dto/WaitingDetailsResponse.java
@@ -1,0 +1,20 @@
+package com.mdh.devtable.waiting.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.mdh.devtable.waiting.domain.WaitingPeople;
+import com.mdh.devtable.waiting.domain.WaitingStatus;
+
+import java.time.LocalDateTime;
+
+public record WaitingDetailsResponse(
+        ShopWaitingResponse shop,
+        int waitingNumber,
+        Integer waitingRank,
+        WaitingStatus waitingStatus,
+        WaitingPeople waitingPeople,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+        LocalDateTime createdDate,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+        LocalDateTime modifiedDate
+) {
+}

--- a/src/main/java/com/mdh/devtable/waiting/domain/WaitingStatus.java
+++ b/src/main/java/com/mdh/devtable/waiting/domain/WaitingStatus.java
@@ -2,5 +2,12 @@ package com.mdh.devtable.waiting.domain;
 
 public enum WaitingStatus {
 
-    PROGRESS, CANCEL, NO_SHOW, VISITED
+    PROGRESS,
+    CANCEL,
+    NO_SHOW,
+    VISITED;
+
+    public boolean isProgress() {
+        return this == WaitingStatus.PROGRESS;
+    }
 }

--- a/src/main/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepository.java
+++ b/src/main/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepository.java
@@ -1,6 +1,7 @@
 package com.mdh.devtable.waiting.infra.persistence;
 
 import com.mdh.devtable.waiting.domain.Waiting;
+import com.mdh.devtable.waiting.infra.persistence.dto.WaitingDetails;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,4 +12,18 @@ public interface WaitingRepository extends JpaRepository<Waiting, Long> {
 
     @Query("select w from Waiting w where w.waitingStatus = 'PROGRESS' and w.userId = :userId")
     Optional<Waiting> findByProgressWaiting(@Param("userId") Long userId);
+
+    @Query("""
+            select
+                new com.mdh.devtable.waiting.infra.persistence.dto.WaitingDetails
+                (
+                    s.name, s.shopType, s.region.district, s.shopDetails.phoneNumber, 
+                    w.waitingNumber, w.waitingStatus, w.waitingPeople.adultCount, w.waitingPeople.childCount, 
+                    w.createdDate, w.modifiedDate
+                )
+            from Waiting w
+            join Shop s on w.shopWaiting.shopId = s.id
+            where w.id = :waitingId
+            """)
+    WaitingDetails findByWaitingDetails(@Param("waitingId") Long waitingId);
 }

--- a/src/main/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepository.java
+++ b/src/main/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepository.java
@@ -17,13 +17,13 @@ public interface WaitingRepository extends JpaRepository<Waiting, Long> {
             select
                 new com.mdh.devtable.waiting.infra.persistence.dto.WaitingDetails
                 (
-                    s.name, s.shopType, s.region.district, s.shopDetails.phoneNumber, 
-                    w.waitingNumber, w.waitingStatus, w.waitingPeople.adultCount, w.waitingPeople.childCount, 
+                    s.name, s.shopType, s.region.district, s.shopDetails, 
+                    w.waitingNumber, w.waitingStatus, w.waitingPeople,
                     w.createdDate, w.modifiedDate
                 )
             from Waiting w
             join Shop s on w.shopWaiting.shopId = s.id
             where w.id = :waitingId
             """)
-    WaitingDetails findByWaitingDetails(@Param("waitingId") Long waitingId);
+    Optional<WaitingDetails> findByWaitingDetails(@Param("waitingId") Long waitingId);
 }

--- a/src/main/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepository.java
+++ b/src/main/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepository.java
@@ -17,7 +17,7 @@ public interface WaitingRepository extends JpaRepository<Waiting, Long> {
             select
                 new com.mdh.devtable.waiting.infra.persistence.dto.WaitingDetails
                 (
-                    s.name, s.shopType, s.region.district, s.shopDetails, 
+                    s.id, s.name, s.shopType, s.region.district, s.shopDetails, 
                     w.waitingNumber, w.waitingStatus, w.waitingPeople,
                     w.createdDate, w.modifiedDate
                 )

--- a/src/main/java/com/mdh/devtable/waiting/infra/persistence/dto/WaitingDetails.java
+++ b/src/main/java/com/mdh/devtable/waiting/infra/persistence/dto/WaitingDetails.java
@@ -1,26 +1,38 @@
 package com.mdh.devtable.waiting.infra.persistence.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
+import com.mdh.devtable.shop.ShopDetails;
 import com.mdh.devtable.shop.ShopType;
+import com.mdh.devtable.waiting.application.dto.ShopWaitingResponse;
+import com.mdh.devtable.waiting.application.dto.WaitingDetailsResponse;
+import com.mdh.devtable.waiting.domain.WaitingPeople;
 import com.mdh.devtable.waiting.domain.WaitingStatus;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
 import java.time.LocalDateTime;
 
-@Getter
-@AllArgsConstructor
-public class WaitingDetails {
-    String shopName;
-    ShopType shopType;
-    String region;
-    String phoneNumber;
-    int waitingNumber;
-    WaitingStatus waitingStatus;
-    int adultCount;
-    int childCount;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
-    LocalDateTime createdAt;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
-    LocalDateTime updatedAt;
+public record WaitingDetails(
+        Long shopId,
+        String shopName,
+        ShopType shopType,
+        String region,
+        ShopDetails shopDetails,
+        int waitingNumber,
+        WaitingStatus waitingStatus,
+        WaitingPeople waitingPeople,
+        LocalDateTime createdDate,
+        LocalDateTime modifiedDate
+) {
+    public WaitingDetailsResponse toWaitingDetailsResponse(Integer waitingRank) {
+        var shopWaitingInfo = new ShopWaitingResponse(shopName, shopType, region, shopDetails);
+        return new WaitingDetailsResponse(shopWaitingInfo,
+                waitingNumber,
+                waitingRank,
+                waitingStatus,
+                waitingPeople,
+                createdDate,
+                modifiedDate);
+    }
+
+    public WaitingDetailsResponse toWaitingDetailsResponse() {
+        return toWaitingDetailsResponse(null);
+    }
 }

--- a/src/main/java/com/mdh/devtable/waiting/infra/persistence/dto/WaitingDetails.java
+++ b/src/main/java/com/mdh/devtable/waiting/infra/persistence/dto/WaitingDetails.java
@@ -1,0 +1,26 @@
+package com.mdh.devtable.waiting.infra.persistence.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.mdh.devtable.shop.ShopType;
+import com.mdh.devtable.waiting.domain.WaitingStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class WaitingDetails {
+    String shopName;
+    ShopType shopType;
+    String region;
+    String phoneNumber;
+    int waitingNumber;
+    WaitingStatus waitingStatus;
+    int adultCount;
+    int childCount;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    LocalDateTime createdAt;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    LocalDateTime updatedAt;
+}

--- a/src/main/java/com/mdh/devtable/waiting/presentation/UserWaitingController.java
+++ b/src/main/java/com/mdh/devtable/waiting/presentation/UserWaitingController.java
@@ -2,6 +2,7 @@ package com.mdh.devtable.waiting.presentation;
 
 import com.mdh.devtable.global.ApiResponse;
 import com.mdh.devtable.waiting.application.WaitingService;
+import com.mdh.devtable.waiting.application.dto.WaitingDetailsResponse;
 import com.mdh.devtable.waiting.presentation.dto.WaitingCreateRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -29,5 +30,11 @@ public class UserWaitingController {
     public ResponseEntity<ApiResponse<Void>> cancelWaiting(@PathVariable Long waitingId) {
         waitingService.cancelWaiting(waitingId);
         return new ResponseEntity<>(ApiResponse.noContent(null), HttpStatus.NO_CONTENT);
+    }
+
+    @GetMapping("/{waitingId}")
+    public ResponseEntity<ApiResponse<WaitingDetailsResponse>> findWaitingDetails(@PathVariable Long waitingId) {
+        var waitingDetailsResponse = waitingService.findWaitingDetails(waitingId);
+        return new ResponseEntity<>(ApiResponse.ok(waitingDetailsResponse), HttpStatus.OK);
     }
 }

--- a/src/test/java/com/mdh/devtable/DataInitializerFactory.java
+++ b/src/test/java/com/mdh/devtable/DataInitializerFactory.java
@@ -6,6 +6,10 @@ import com.mdh.devtable.user.domain.User;
 import com.mdh.devtable.waiting.domain.ShopWaiting;
 import com.mdh.devtable.waiting.domain.Waiting;
 import com.mdh.devtable.waiting.domain.WaitingPeople;
+import com.mdh.devtable.waiting.domain.WaitingStatus;
+import com.mdh.devtable.waiting.infra.persistence.dto.WaitingDetails;
+
+import java.time.LocalDateTime;
 
 public final class DataInitializerFactory {
 
@@ -92,5 +96,20 @@ public final class DataInitializerFactory {
                 .shopWaiting(shopWaiting)
                 .waitingPeople(waitingPeople)
                 .build();
+    }
+
+    public static WaitingDetails waitingDetails(ShopDetails shopDetails,
+                                                WaitingStatus waitingStatus,
+                                                WaitingPeople waitingPeople) {
+        return new WaitingDetails(1L,
+                "가게 이름",
+                ShopType.KOREAN,
+                "강남구",
+                shopDetails,
+                85,
+                waitingStatus,
+                waitingPeople,
+                LocalDateTime.now(),
+                LocalDateTime.now());
     }
 }

--- a/src/test/java/com/mdh/devtable/ownerwaiting/application/OwnerWaitingLockTest.java
+++ b/src/test/java/com/mdh/devtable/ownerwaiting/application/OwnerWaitingLockTest.java
@@ -1,6 +1,6 @@
-package com.mdh.devtable.ownerwaitng.application;
+package com.mdh.devtable.ownerwaiting.application;
 
-import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
+import com.mdh.devtable.ownerwaiting.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
 import com.mdh.devtable.waiting.domain.ShopWaitingStatus;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Disabled;

--- a/src/test/java/com/mdh/devtable/ownerwaiting/application/OwnerWaitingServiceTest.java
+++ b/src/test/java/com/mdh/devtable/ownerwaiting/application/OwnerWaitingServiceTest.java
@@ -1,8 +1,8 @@
-package com.mdh.devtable.ownerwaitng.application;
+package com.mdh.devtable.ownerwaiting.application;
 
-import com.mdh.devtable.ownerwaitng.infra.persistence.OwnerWaitingRepository;
-import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
-import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerWaitingStatusChangeRequest;
+import com.mdh.devtable.ownerwaiting.infra.persistence.OwnerWaitingRepository;
+import com.mdh.devtable.ownerwaiting.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
+import com.mdh.devtable.ownerwaiting.presentaion.dto.OwnerWaitingStatusChangeRequest;
 import com.mdh.devtable.waiting.domain.*;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/mdh/devtable/ownerwaiting/application/OwnerWaitingServiceTest.java
+++ b/src/test/java/com/mdh/devtable/ownerwaiting/application/OwnerWaitingServiceTest.java
@@ -1,9 +1,11 @@
 package com.mdh.devtable.ownerwaiting.application;
 
+import com.mdh.devtable.DataInitializerFactory;
 import com.mdh.devtable.ownerwaiting.infra.persistence.OwnerWaitingRepository;
 import com.mdh.devtable.ownerwaiting.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
 import com.mdh.devtable.ownerwaiting.presentaion.dto.OwnerWaitingStatusChangeRequest;
-import com.mdh.devtable.waiting.domain.*;
+import com.mdh.devtable.waiting.domain.ShopWaitingStatus;
+import com.mdh.devtable.waiting.domain.WaitingStatus;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,13 +37,7 @@ class OwnerWaitingServiceTest {
     void changeShopWaitingStatus(String status) {
         //given
         var shopId = 1L;
-        var shopWaiting = ShopWaiting
-                .builder()
-                .shopId(shopId)
-                .maximumWaitingPeople(2)
-                .minimumWaitingPeople(1)
-                .maximumWaiting(10)
-                .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, 2, 1, 1);
         var request = new OwnerShopWaitingStatusChangeRequest(ShopWaitingStatus.valueOf(status));
         given(ownerWaitingRepository.findShopWaitingByShopId(shopId)).willReturn(Optional.of(shopWaiting));
 
@@ -58,20 +54,11 @@ class OwnerWaitingServiceTest {
     @ValueSource(strings = {"PROGRESS", "CANCEL", "NO_SHOW", "VISITED"})
     void changeWaitingStatus(String status) {
         //given
-        var shopWaiting = ShopWaiting
-                .builder()
-                .shopId(1L)
-                .maximumWaitingPeople(2)
-                .minimumWaitingPeople(1)
-                .maximumWaiting(10)
-                .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(1L, 2, 1, 1);
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
         var waitingId = 1L;
-        var waiting = Waiting.builder()
-                .shopWaiting(shopWaiting)
-                .userId(1L)
-                .waitingPeople(new WaitingPeople(1, 0))
-                .build();
+        var waitingPeople = DataInitializerFactory.waitingPeople(1, 0);
+        var waiting = DataInitializerFactory.waiting(1L, shopWaiting, waitingPeople);
 
         var request = new OwnerWaitingStatusChangeRequest(WaitingStatus.valueOf(status));
         given(ownerWaitingRepository.findWaitingByWaitingId(waitingId)).willReturn(Optional.of(waiting));

--- a/src/test/java/com/mdh/devtable/ownerwaiting/presentaion/controller/OwnerWaitingControllerTest.java
+++ b/src/test/java/com/mdh/devtable/ownerwaiting/presentaion/controller/OwnerWaitingControllerTest.java
@@ -1,9 +1,9 @@
-package com.mdh.devtable.ownerwaitng.presentaion.controller;
+package com.mdh.devtable.ownerwaiting.presentaion.controller;
 
 import com.mdh.devtable.RestDocsSupport;
-import com.mdh.devtable.ownerwaitng.application.OwnerWaitingService;
-import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
-import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerWaitingStatusChangeRequest;
+import com.mdh.devtable.ownerwaiting.application.OwnerWaitingService;
+import com.mdh.devtable.ownerwaiting.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
+import com.mdh.devtable.ownerwaiting.presentaion.dto.OwnerWaitingStatusChangeRequest;
 import com.mdh.devtable.waiting.domain.ShopWaitingStatus;
 import com.mdh.devtable.waiting.domain.WaitingStatus;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/mdh/devtable/ownerwaitng/application/OwnerWaitingServiceTest.java
+++ b/src/test/java/com/mdh/devtable/ownerwaitng/application/OwnerWaitingServiceTest.java
@@ -4,7 +4,7 @@ import com.mdh.devtable.ownerwaitng.infra.persistence.OwnerWaitingRepository;
 import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
 import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerWaitingStatusChangeRequest;
 import com.mdh.devtable.waiting.domain.*;
-import org.junit.jupiter.api.Assertions;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -50,7 +50,7 @@ class OwnerWaitingServiceTest {
 
         // then
         verify(ownerWaitingRepository, times(1)).findShopWaitingByShopId(shopId);
-        Assertions.assertEquals(ShopWaitingStatus.valueOf(status), shopWaiting.getShopWaitingStatus());
+        Assertions.assertThat(ShopWaitingStatus.valueOf(status)).isEqualTo(shopWaiting.getShopWaitingStatus());
     }
 
     @DisplayName("손님의 웨이팅 상태를 변경할 수 있다.")
@@ -81,6 +81,6 @@ class OwnerWaitingServiceTest {
 
         // then
         verify(ownerWaitingRepository, times(1)).findWaitingByWaitingId(waitingId);
-        Assertions.assertEquals(WaitingStatus.valueOf(status), waiting.getWaitingStatus());
+        Assertions.assertThat(WaitingStatus.valueOf(status)).isEqualTo(waiting.getWaitingStatus());
     }
 }

--- a/src/test/java/com/mdh/devtable/ownerwaitng/presentaion/controller/OwnerWaitingControllerTest.java
+++ b/src/test/java/com/mdh/devtable/ownerwaitng/presentaion/controller/OwnerWaitingControllerTest.java
@@ -3,7 +3,9 @@ package com.mdh.devtable.ownerwaitng.presentaion.controller;
 import com.mdh.devtable.RestDocsSupport;
 import com.mdh.devtable.ownerwaitng.application.OwnerWaitingService;
 import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
+import com.mdh.devtable.ownerwaitng.presentaion.dto.OwnerWaitingStatusChangeRequest;
 import com.mdh.devtable.waiting.domain.ShopWaitingStatus;
+import com.mdh.devtable.waiting.domain.WaitingStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -76,6 +78,64 @@ class OwnerWaitingControllerTest extends RestDocsSupport {
                 .andDo(document("user-sign-up-invalid-password",
                         requestFields(
                                 fieldWithPath("shopWaitingStatus").type(JsonFieldType.STRING).description("매장 상태")
+                        ),
+                        responseFields(
+                                fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("상태 코드"),
+                                fieldWithPath("data.type").type(JsonFieldType.STRING).description("타입"),
+                                fieldWithPath("data.title").type(JsonFieldType.STRING).description("타이틀"),
+                                fieldWithPath("data.status").type(JsonFieldType.NUMBER).description("상태 코드"),
+                                fieldWithPath("data.detail").type(JsonFieldType.STRING).description("상세 설명"),
+                                fieldWithPath("data.instance").type(JsonFieldType.STRING).description("인스턴스 URI"),
+                                fieldWithPath("serverDateTime").type(JsonFieldType.STRING).description("서버 시간")
+                        )
+                ));
+    }
+
+    @DisplayName("매장의 웨이팅 상태를 변경할 수 있다.")
+    @Test
+    void changWaitingStatus() throws Exception {
+        //given
+        var waitingId = 1L;
+        var request = new OwnerWaitingStatusChangeRequest(WaitingStatus.VISITED);
+        doNothing().when(ownerWaitingService).changeWaitingStatus(waitingId, request);
+
+        //when & then
+        mockMvc.perform(patch("/api/owner/v1/waitings/" + waitingId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value("200"))
+                .andExpect(jsonPath("$.data").doesNotExist())
+                .andExpect(jsonPath("$.serverDateTime").exists())
+                .andDo(document("owner-shops-waiting",
+                        requestFields(
+                                fieldWithPath("waitingStatus").type(JsonFieldType.STRING).description("웨이팅 상태")
+                        ),
+                        responseFields(fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("상태 코드"),
+                                fieldWithPath("data").type(JsonFieldType.NULL).description("응답 바디(비어있음)"),
+                                fieldWithPath("serverDateTime").type(JsonFieldType.STRING).description("변경된 서버 시간")
+                        )
+                ));
+    }
+
+    @DisplayName("매장의 웨이팅 상태를 잘못된 형태로 변경할 수 없다.")
+    @Test
+    void changWaitingStatusThrowException() throws Exception {
+        //given
+        var waitingId = 1L;
+        var request = new HashMap<String, String>();
+        request.put("waitingStatus", "asf");
+
+        //when & then
+        mockMvc.perform(patch("/api/owner/v1/waitings/" + waitingId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.statusCode").value("400"))
+                .andExpect(jsonPath("$.data.title").value("HttpMessageNotReadableException"))
+                .andDo(document("user-sign-up-invalid-password",
+                        requestFields(
+                                fieldWithPath("waitingStatus").type(JsonFieldType.STRING).description("웨이팅 상태")
                         ),
                         responseFields(
                                 fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("상태 코드"),

--- a/src/test/java/com/mdh/devtable/shop/ShopTest.java
+++ b/src/test/java/com/mdh/devtable/shop/ShopTest.java
@@ -1,5 +1,6 @@
 package com.mdh.devtable.shop;
 
+import com.mdh.devtable.DataInitializerFactory;
 import org.hibernate.AssertionFailure;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -15,38 +16,12 @@ class ShopTest {
     void shopConstructorTest() {
         // given
         var userId = 1L;
-
-        var shopDetails = ShopDetails.builder()
-                .url("www.example.com")
-                .holiday("일요일")
-                .openingHours("11시")
-                .phoneNumber("01012345678")
-                .info("정보")
-                .introduce("introduce")
-                .build();
-
-        var shopAddress = ShopAddress.builder()
-                .address("가로수길 31-3, 301호")
-                .zipcode("11111")
-                .latitude("123.123")
-                .longitude("123.123")
-                .build();
-
-        var region = Region.builder()
-                .city("서울시")
-                .district("강남구")
-                .build();
+        var shopDetails = DataInitializerFactory.shopDetails();
+        var shopAddress = DataInitializerFactory.shopAddress();
+        var region = DataInitializerFactory.region();
 
         // when
-        Shop shop = Shop.builder()
-                .userId(userId)
-                .name("Test Shop")
-                .description("This is a test shop")
-                .shopType(ShopType.KOREAN) // 가정: ShopType 열거형에 TYPE1이 있음
-                .shopDetails(shopDetails)
-                .shopAddress(shopAddress)
-                .region(region)
-                .build();
+        var shop = DataInitializerFactory.shop(userId, shopDetails, region, shopAddress);
 
         // then
         assertThat(shop)
@@ -58,9 +33,9 @@ class ShopTest {
                         Shop::getShopAddress,
                         Shop::getRegion)
                 .containsExactly(0,
-                        "Test Shop",
-                        "This is a test shop",
-                        ShopType.KOREAN,
+                        "가게 이름",
+                        "가게의 간단한 설명",
+                        ShopType.AMERICAN,
                         shopDetails,
                         shopAddress,
                         region);
@@ -80,36 +55,10 @@ class ShopTest {
         // given
         var userId = 1L;
 
-        var shopDetails = ShopDetails.builder()
-                .url("www.example.com")
-                .holiday("일요일")
-                .openingHours("11시")
-                .phoneNumber("01012345678")
-                .info("정보")
-                .introduce("introduce")
-                .build();
-
-        var shopAddress = ShopAddress.builder()
-                .address("잠실로 62, 302동 202호")
-                .zipcode("11111")
-                .latitude("123.123")
-                .longitude("123.123")
-                .build();
-
-        var region = Region.builder()
-                .city("서울시")
-                .district("강남구")
-                .build();
-
-        Shop shop = Shop.builder()
-                .userId(1L)
-                .name("Test Shop")
-                .description("This is a test shop")
-                .shopType(ShopType.KOREAN) // 가정: ShopType 열거형에 TYPE1이 있음
-                .shopDetails(shopDetails)
-                .shopAddress(shopAddress)
-                .region(region)
-                .build();
+        var shopDetails = DataInitializerFactory.shopDetails();
+        var shopAddress = DataInitializerFactory.shopAddress();
+        var region = DataInitializerFactory.region();
+        var shop = DataInitializerFactory.shop(userId, shopDetails, region, shopAddress);
 
         String changeName = "changedName";
         String changeDescription = "changedDescription";
@@ -176,37 +125,10 @@ class ShopTest {
     void increaseBookMarks() {
         // given
         var userId = 1L;
-
-        var shopDetails = ShopDetails.builder()
-                .url("www.example.com")
-                .holiday("일요일")
-                .openingHours("11시")
-                .phoneNumber("01012345678")
-                .info("정보")
-                .introduce("introduce")
-                .build();
-
-        var shopAddress = ShopAddress.builder()
-                .address("서울시 강남구")
-                .zipcode("11111")
-                .latitude("123.123")
-                .longitude("123.123")
-                .build();
-
-        var region = Region.builder()
-                .city("서울시")
-                .district("강남구")
-                .build();
-
-        Shop shop = Shop.builder()
-                .userId(1L)
-                .name("Test Shop")
-                .description("This is a test shop")
-                .shopType(ShopType.KOREAN)
-                .shopDetails(shopDetails)
-                .shopAddress(shopAddress)
-                .region(region)
-                .build();
+        var shopDetails = DataInitializerFactory.shopDetails();
+        var shopAddress = DataInitializerFactory.shopAddress();
+        var region = DataInitializerFactory.region();
+        var shop = DataInitializerFactory.shop(userId, shopDetails, region, shopAddress);
 
         // when
         shop.increaseBookmarkCount();
@@ -220,37 +142,10 @@ class ShopTest {
     void decreaseBookMarks() {
         // given
         var userId = 1L;
-
-        var shopDetails = ShopDetails.builder()
-                .url("www.example.com")
-                .holiday("일요일")
-                .openingHours("11시")
-                .phoneNumber("01012345678")
-                .info("정보")
-                .introduce("introduce")
-                .build();
-
-        var shopAddress = ShopAddress.builder()
-                .address("서울시 강남구")
-                .zipcode("11111")
-                .latitude("123.123")
-                .longitude("123.123")
-                .build();
-
-        var region = Region.builder()
-                .city("서울시")
-                .district("강남구")
-                .build();
-
-        Shop shop = Shop.builder()
-                .userId(1L)
-                .name("Test Shop")
-                .description("This is a test shop")
-                .shopType(ShopType.KOREAN) // 가정: ShopType 열거형에 TYPE1이 있음
-                .shopDetails(shopDetails)
-                .shopAddress(shopAddress)
-                .region(region)
-                .build();
+        var shopDetails = DataInitializerFactory.shopDetails();
+        var shopAddress = DataInitializerFactory.shopAddress();
+        var region = DataInitializerFactory.region();
+        var shop = DataInitializerFactory.shop(userId, shopDetails, region, shopAddress);
 
         // when
         shop.increaseBookmarkCount();
@@ -265,39 +160,12 @@ class ShopTest {
     void bookMarkThrowsExceptionWhenBookMarkCountisZero() {
         // given
         var userId = 1L;
+        var shopDetails = DataInitializerFactory.shopDetails();
+        var shopAddress = DataInitializerFactory.shopAddress();
+        var region = DataInitializerFactory.region();
+        var shop = DataInitializerFactory.shop(userId, shopDetails, region, shopAddress);
 
-        var shopDetails = ShopDetails.builder()
-                .url("www.example.com")
-                .holiday("일요일")
-                .openingHours("11시")
-                .phoneNumber("01012345678")
-                .info("정보")
-                .introduce("introduce")
-                .build();
-
-        var shopAddress = ShopAddress.builder()
-                .address("서울시 강남구")
-                .zipcode("11111")
-                .latitude("123.123")
-                .longitude("123.123")
-                .build();
-
-        var region = Region.builder()
-                .city("서울시")
-                .district("강남구")
-                .build();
-
-        Shop shop = Shop.builder()
-                .userId(1L)
-                .name("Test Shop")
-                .description("This is a test shop")
-                .shopType(ShopType.KOREAN)
-                .shopDetails(shopDetails)
-                .shopAddress(shopAddress)
-                .region(region)
-                .build();
-
-        // when&then
+        // when & then
         assertThatThrownBy(shop::decreaseBookmarkCount)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("북마크 개수가 0 일 때 북마크 개수를 줄이는 것은 불가능합니다.");

--- a/src/test/java/com/mdh/devtable/user/application/UserServiceTest.java
+++ b/src/test/java/com/mdh/devtable/user/application/UserServiceTest.java
@@ -1,25 +1,27 @@
 package com.mdh.devtable.user.application;
 
+import com.mdh.devtable.user.domain.User;
 import com.mdh.devtable.user.infra.persistence.UserRepository;
 import com.mdh.devtable.user.presentation.dto.SignUpRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
-@SpringBootTest
-@Transactional
-@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
 public class UserServiceTest {
 
-    @Autowired
+    @InjectMocks
     private UserService userService;
 
-    @Autowired
+    @Mock
     private UserRepository userRepository;
 
     @Test
@@ -28,15 +30,12 @@ public class UserServiceTest {
         // given
         var signUpRequest = new SignUpRequest("test@example.com", "password123", "password123");
         var expectedUser = signUpRequest.toEntity();
+        given(userRepository.save(any(User.class))).willReturn(expectedUser);
 
         // when
         userService.signUp(signUpRequest);
 
         // then
-        var actualUser = userRepository.findByEmail("test@example.com").orElse(null);
-        assertThat(actualUser).isNotNull();
-        assertThat(actualUser.getEmail()).isEqualTo(expectedUser.getEmail());
-        assertThat(actualUser.getRole()).isEqualTo(expectedUser.getRole());
-        assertThat(actualUser.getPassword()).isEqualTo(expectedUser.getPassword());
+        verify(userRepository, times(1)).save(any(User.class));
     }
 }

--- a/src/test/java/com/mdh/devtable/user/domain/UserTest.java
+++ b/src/test/java/com/mdh/devtable/user/domain/UserTest.java
@@ -1,6 +1,7 @@
 package com.mdh.devtable.user.domain;
 
 
+import com.mdh.devtable.DataInitializerFactory;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,14 +11,8 @@ class UserTest {
     @Test
     @DisplayName("유저를 생성할 수 있다.")
     void couldCreateUser() {
-        // given
-
-        // when
-        var user = User.builder()
-                .email("test@example.com")
-                .role(Role.GUEST)
-                .password("password123")
-                .build();
+        // given & when
+        var user = DataInitializerFactory.guest();
 
         // then
         Assertions.assertThat(user).isNotNull();

--- a/src/test/java/com/mdh/devtable/waiting/ShopWaitingTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/ShopWaitingTest.java
@@ -1,5 +1,6 @@
 package com.mdh.devtable.waiting;
 
+import com.mdh.devtable.DataInitializerFactory;
 import com.mdh.devtable.waiting.domain.ShopWaiting;
 import com.mdh.devtable.waiting.domain.ShopWaitingStatus;
 import org.junit.jupiter.api.DisplayName;
@@ -22,13 +23,7 @@ class ShopWaitingTest {
         var maximumWaiting = 10;
 
         //when
-        var shopWaiting = ShopWaiting
-                .builder()
-                .shopId(shopId)
-                .maximumWaitingPeople(2)
-                .minimumWaitingPeople(1)
-                .maximumWaiting(maximumWaiting)
-                .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, 2, 1);
 
         //then
         assertThat(shopWaiting.getShopId()).isEqualTo(shopId);
@@ -60,11 +55,7 @@ class ShopWaitingTest {
         var shopId = 1L;
         var maximumWaiting = 10;
 
-        var shopWaiting = ShopWaiting
-                .builder()
-                .shopId(shopId)
-                .maximumWaiting(maximumWaiting)
-                .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, 2, 1);
 
         //when
         shopWaiting.changeShopWaitingStatus(shopWaitingStatus);
@@ -80,11 +71,7 @@ class ShopWaitingTest {
         var shopId = 1L;
         var maximumWaiting = 10;
 
-        var shopWaiting = ShopWaiting
-                .builder()
-                .shopId(shopId)
-                .maximumWaiting(maximumWaiting)
-                .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, 2, 1);
 
         //when & then
         assertThatThrownBy(() -> shopWaiting.changeShopWaitingStatus(shopWaiting.getShopWaitingStatus()))
@@ -100,11 +87,7 @@ class ShopWaitingTest {
         var shopId = 1L;
         var maximumWaiting = 10;
 
-        var shopWaiting = ShopWaiting
-                .builder()
-                .shopId(shopId)
-                .maximumWaiting(maximumWaiting)
-                .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, 2, 1);
 
         //when
         shopWaiting.updateShopWaiting(changeMaximumWaiting);
@@ -120,11 +103,7 @@ class ShopWaitingTest {
         var shopId = 1L;
         var maximumWaiting = 10;
 
-        var shopWaiting = ShopWaiting
-                .builder()
-                .shopId(shopId)
-                .maximumWaiting(maximumWaiting)
-                .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, 2, 1);
 
         //when & then
         assertThatThrownBy(() -> shopWaiting.updateShopWaiting(0))
@@ -137,11 +116,9 @@ class ShopWaitingTest {
     void updateChildEnabled() {
         // given
         var shopId = 1L;
-        var maximumWaiting = 5;
-        var shopWaiting = ShopWaiting.builder()
-                .shopId(shopId)
-                .maximumWaiting(maximumWaiting)
-                .build();
+        var maximumWaiting = 10;
+
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, 2, 1);
 
         // when
         var newChildEnabled = true;
@@ -156,11 +133,9 @@ class ShopWaitingTest {
     void initShopWaitingCountTest() {
         //given
         var shopId = 1L;
-        var maximumWaiting = 5;
-        var shopWaiting = ShopWaiting.builder()
-                .shopId(shopId)
-                .maximumWaiting(maximumWaiting)
-                .build();
+        var maximumWaiting = 10;
+
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, 2, 1);
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
 
@@ -178,11 +153,9 @@ class ShopWaitingTest {
     void addShopWaitingCountExTest() {
         //given
         var shopId = 1L;
-        var maximumWaiting = 5;
-        var shopWaiting = ShopWaiting.builder()
-                .shopId(shopId)
-                .maximumWaiting(maximumWaiting)
-                .build();
+        var maximumWaiting = 10;
+
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, 2, 1);
 
         //when & then
         assertThatThrownBy(shopWaiting::addWaitingCount)

--- a/src/test/java/com/mdh/devtable/waiting/WaitingTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/WaitingTest.java
@@ -1,10 +1,7 @@
 package com.mdh.devtable.waiting;
 
-import com.mdh.devtable.waiting.domain.ShopWaiting;
-import com.mdh.devtable.waiting.domain.ShopWaitingStatus;
-import com.mdh.devtable.waiting.domain.Waiting;
-import com.mdh.devtable.waiting.domain.WaitingPeople;
-import com.mdh.devtable.waiting.domain.WaitingStatus;
+import com.mdh.devtable.DataInitializerFactory;
+import com.mdh.devtable.waiting.domain.*;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,40 +28,31 @@ class WaitingTest {
         var minimumWaitingPeople = 2;
         var maximumWaitingPeople = 5;
 
-        var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, maximumWaitingPeople, minimumWaitingPeople);
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
 
         //when
-        var waiting = Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .userId(userId)
-            .waitingPeople(waitingPeople)
-            .build();
+        var waiting = DataInitializerFactory.waiting(userId, shopWaiting, waitingPeople);
 
         //then
         assertThat(waiting)
-            .extracting(Waiting::getWaitingPeople,
-                Waiting::getShopWaiting,
-                Waiting::getUserId,
-                Waiting::getWaitingStatus,
-                Waiting::getPostponedCount)
-            .containsExactly(waitingPeople,
-                shopWaiting,
-                userId,
-                WaitingStatus.PROGRESS,
-                0);
+                .extracting(Waiting::getWaitingPeople,
+                        Waiting::getShopWaiting,
+                        Waiting::getUserId,
+                        Waiting::getWaitingStatus,
+                        Waiting::getPostponedCount)
+                .containsExactly(waitingPeople,
+                        shopWaiting,
+                        userId,
+                        WaitingStatus.PROGRESS,
+                        0);
     }
 
     static Stream<Arguments> waitingPeople() {
         return Stream.of(
-            Arguments.arguments(new WaitingPeople(2, 0)),
-            Arguments.arguments(new WaitingPeople(5, 0))
+                Arguments.arguments(DataInitializerFactory.waitingPeople(5, 0)),
+                Arguments.arguments(DataInitializerFactory.waitingPeople(5, 0))
         );
     }
 
@@ -79,26 +67,21 @@ class WaitingTest {
         var minimumWaitingPeople = 2;
         var maximumWaitingPeople = 5;
 
-        var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, maximumWaitingPeople, minimumWaitingPeople);
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
         shopWaiting.changeShopWaitingStatus(waitingStatus);
 
-        var waitingPeople = new WaitingPeople(2, 0);
+        var waitingPeople = DataInitializerFactory.waitingPeople(2, 0);
 
         //when & then
         assertThatThrownBy(() -> Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .userId(userId)
-            .waitingPeople(waitingPeople)
-            .build())
-            .isInstanceOf(IllegalStateException.class)
-            .hasMessage("매장이 오픈 상태가 아니면 웨이팅을 등록 할 수 없습니다.");
+                .shopWaiting(shopWaiting)
+                .userId(userId)
+                .waitingPeople(waitingPeople)
+                .build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("매장이 오픈 상태가 아니면 웨이팅을 등록 할 수 없습니다.");
     }
 
     @Test
@@ -111,22 +94,14 @@ class WaitingTest {
         var minimumWaitingPeople = 2;
         var maximumWaitingPeople = 5;
 
-        var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, maximumWaitingPeople, minimumWaitingPeople);
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
 
-        var waitingPeople = new WaitingPeople(2, 0);
+        var waitingPeople = DataInitializerFactory.waitingPeople(2, 0);
 
-        var waiting = Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .userId(userId)
-            .waitingPeople(waitingPeople)
-            .build();
+        var waiting = DataInitializerFactory.waiting(userId, shopWaiting, waitingPeople);
+
         //when
         waiting.addPostponedCount();
 
@@ -146,30 +121,21 @@ class WaitingTest {
         var minimumWaitingPeople = 2;
         var maximumWaitingPeople = 5;
 
-        var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, maximumWaitingPeople, minimumWaitingPeople);
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
 
-        var waitingPeople = new WaitingPeople(2, 0);
+        var waitingPeople = DataInitializerFactory.waitingPeople(2, 0);
 
-        var waiting = Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .userId(userId)
-            .waitingPeople(waitingPeople)
-            .build();
+        var waiting = DataInitializerFactory.waiting(userId, shopWaiting, waitingPeople);
 
         //when
         waiting.changeWaitingStatus(waitingStatus);
 
         //then
         Assertions.assertThatThrownBy(waiting::addPostponedCount)
-            .isInstanceOf(IllegalStateException.class)
-            .hasMessage("진행 상태가 아닌 웨이팅 미루기는 불가능 합니다.");
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("진행 상태가 아닌 웨이팅 미루기는 불가능 합니다.");
     }
 
     @Test
@@ -182,22 +148,13 @@ class WaitingTest {
         var minimumWaitingPeople = 2;
         var maximumWaitingPeople = 5;
 
-        var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, maximumWaitingPeople, minimumWaitingPeople);
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
 
-        var waitingPeople = new WaitingPeople(2, 0);
+        var waitingPeople = DataInitializerFactory.waitingPeople(2, 0);
 
-        var waiting = Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .userId(userId)
-            .waitingPeople(waitingPeople)
-            .build();
+        var waiting = DataInitializerFactory.waiting(userId, shopWaiting, waitingPeople);
 
         //when
         waiting.addPostponedCount();
@@ -205,8 +162,8 @@ class WaitingTest {
 
         //then
         Assertions.assertThatThrownBy(waiting::addPostponedCount)
-            .isInstanceOf(IllegalStateException.class)
-            .hasMessage("웨이팅 미루기는 2회 초과하여 불가능 합니다.");
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("웨이팅 미루기는 2회 초과하여 불가능 합니다.");
     }
 
     @ParameterizedTest
@@ -214,28 +171,20 @@ class WaitingTest {
     @DisplayName("Waiting의 상태가 PROGRESS라면 다른 상태로 변경이 가능하다.")
     public void changeWaitingStatusTest(WaitingStatus waitingStatus) {
         //given
+        //given
         var shopId = 1L;
         var userId = 1L;
         var maximumWaiting = 10;
         var minimumWaitingPeople = 2;
         var maximumWaitingPeople = 5;
 
-        var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, maximumWaitingPeople, minimumWaitingPeople);
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
 
-        var waitingPeople = new WaitingPeople(2, 0);
+        var waitingPeople = DataInitializerFactory.waitingPeople(2, 0);
 
-        var waiting = Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .userId(userId)
-            .waitingPeople(waitingPeople)
-            .build();
+        var waiting = DataInitializerFactory.waiting(userId, shopWaiting, waitingPeople);
 
         //when
         waiting.changeWaitingStatus(waitingStatus);
@@ -255,30 +204,21 @@ class WaitingTest {
         var minimumWaitingPeople = 2;
         var maximumWaitingPeople = 5;
 
-        var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, maximumWaitingPeople, minimumWaitingPeople);
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
 
-        var waitingPeople = new WaitingPeople(2, 0);
+        var waitingPeople = DataInitializerFactory.waitingPeople(2, 0);
 
-        var waiting = Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .userId(userId)
-            .waitingPeople(waitingPeople)
-            .build();
+        var waiting = DataInitializerFactory.waiting(userId, shopWaiting, waitingPeople);
 
         //when
         waiting.changeWaitingStatus(waitingStatus);
 
         //then
         assertThatThrownBy(() -> waiting.changeWaitingStatus(WaitingStatus.PROGRESS))
-            .isInstanceOf(IllegalStateException.class)
-            .hasMessage("진행 상태가 아니면 상태 변경이 불가능 합니다.");
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("진행 상태가 아니면 상태 변경이 불가능 합니다.");
     }
 
     @ParameterizedTest
@@ -291,29 +231,24 @@ class WaitingTest {
         var minimumWaitingPeople = 2;
         var maximumWaitingPeople = 5;
 
-        var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, maximumWaitingPeople, minimumWaitingPeople);
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
 
         //when&then
         assertThatThrownBy(() -> Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .waitingPeople(waitingPeople)
-            .userId(1L)
-            .build())
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage(exceptionMessage);
+                .shopWaiting(shopWaiting)
+                .waitingPeople(waitingPeople)
+                .userId(1L)
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(exceptionMessage);
     }
 
     static Stream<Arguments> waitingPeopleAndExceptionMessage() {
         return Stream.of(
-            Arguments.arguments(new WaitingPeople(1, 0), "웨이팅 인원은 2명 이상이어야 합니다."),
-            Arguments.arguments(new WaitingPeople(6, 0), "웨이팅 인원은 5명 이하여야 합니다.")
+                Arguments.arguments(DataInitializerFactory.waitingPeople(1, 0), "웨이팅 인원은 2명 이상이어야 합니다."),
+                Arguments.arguments(DataInitializerFactory.waitingPeople(6, 0), "웨이팅 인원은 5명 이하여야 합니다.")
         );
     }
 
@@ -327,25 +262,25 @@ class WaitingTest {
         var maximumWaitingPeople = 5;
 
         var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .minimumWaitingPeople(minimumWaitingPeople)
+                .maximumWaitingPeople(maximumWaitingPeople)
+                .build();
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
 
         //when & then
         assertThatThrownBy(() -> Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .waitingPeople(new WaitingPeople(2, 2))
-            .build())
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("유아 손님 입장이 불가능한 매장입니다.");
+                .shopWaiting(shopWaiting)
+                .waitingPeople(new WaitingPeople(2, 2))
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("유아 손님 입장이 불가능한 매장입니다.");
     }
 
     @Test
-    @DisplayName("아동 손님을 받지 매장에 아동 손님을 추가할 수 있다.")
+    @DisplayName("아동 손님을 받는 매장에 아동 손님을 추가할 수 있다.")
     void shouldNotThrowExceptionWhenAddingChildGuestToChildEnabledStore() {
         //given
         var shopId = 1L;
@@ -353,21 +288,13 @@ class WaitingTest {
         var minimumWaitingPeople = 2;
         var maximumWaitingPeople = 5;
 
-        var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, maximumWaitingPeople, minimumWaitingPeople);
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
         shopWaiting.updateChildEnabled(true);
 
         //when
-        var waiting = Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .waitingPeople(new WaitingPeople(2, 2))
-            .build();
+        var waiting = DataInitializerFactory.waiting(1L, shopWaiting, DataInitializerFactory.waitingPeople(2, 2));
 
         //then
         assertThat(waiting).isNotNull();

--- a/src/test/java/com/mdh/devtable/waiting/application/WaitingServiceTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/application/WaitingServiceTest.java
@@ -8,16 +8,19 @@ import com.mdh.devtable.waiting.infra.persistence.ShopWaitingRepository;
 import com.mdh.devtable.waiting.infra.persistence.WaitingLine;
 import com.mdh.devtable.waiting.infra.persistence.WaitingRepository;
 import com.mdh.devtable.waiting.presentation.dto.WaitingCreateRequest;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -92,7 +95,7 @@ class WaitingServiceTest {
         //then
         verify(waitingRepository, times(1)).findById(any(Long.class));
         verify(waitingLine, times(1)).cancel(any(Long.class), any(), any());
-        Assertions.assertThat(WaitingStatus.CANCEL).isEqualTo(waiting.getWaitingStatus());
+        assertThat(WaitingStatus.CANCEL).isEqualTo(waiting.getWaitingStatus());
     }
 
     @Test
@@ -117,4 +120,72 @@ class WaitingServiceTest {
                 .hasMessageContaining("해당 매장에 이미 웨이팅이 등록되어있다면 웨이팅을 추가로 등록 할 수 없다. userId : " + userId);
     }
 
+    @Test
+    @DisplayName("웨이팅이 진행 상태의 경우 상세 정보를 조회할 때 웨이팅 순위도 함께 조회된다.")
+    void findWaitingDetailsProgressStatusTest() {
+        //given
+        var waitingId = 1L;
+
+        var shopDetails = DataInitializerFactory.shopDetails();
+        var waitingPeople = DataInitializerFactory.waitingPeople(2, 0);
+        var waitingStatus = WaitingStatus.PROGRESS;
+        var waitingDetails = DataInitializerFactory.waitingDetails(shopDetails, waitingStatus, waitingPeople);
+
+        var waitingRank = 5;
+
+        given(waitingRepository.findByWaitingDetails(any(Long.class))).willReturn(Optional.ofNullable(waitingDetails));
+        given(waitingLine.findRank(any(Long.class), any(Long.class), any(LocalDateTime.class))).willReturn(waitingRank);
+
+        //when
+        var waitingDetailsResponse = waitingService.findWaitingDetails(waitingId);
+
+        //then
+        verify(waitingRepository, times(1)).findByWaitingDetails(any(Long.class));
+        verify(waitingLine, times(1)).findRank(any(Long.class),
+                any(Long.class),
+                any(LocalDateTime.class));
+        assertThat(waitingDetailsResponse.shop().shopName()).isEqualTo(waitingDetails.shopName());
+        assertThat(waitingDetailsResponse.shop().shopType()).isEqualTo(waitingDetails.shopType());
+        assertThat(waitingDetailsResponse.shop().region()).isEqualTo(waitingDetails.region());
+        assertThat(waitingDetailsResponse.shop().shopDetails()).usingRecursiveComparison().isEqualTo(shopDetails);
+        assertThat(waitingDetailsResponse.waitingNumber()).isEqualTo(waitingDetails.waitingNumber());
+        assertThat(waitingDetailsResponse.waitingStatus()).isEqualTo(waitingStatus);
+        assertThat(waitingDetailsResponse.waitingPeople()).usingRecursiveComparison().isEqualTo(waitingPeople);
+        assertThat(waitingDetailsResponse.waitingRank()).isEqualTo(waitingRank);
+        assertThat(waitingDetailsResponse.createdDate()).isEqualTo(waitingDetails.createdDate());
+        assertThat(waitingDetailsResponse.modifiedDate()).isEqualTo(waitingDetails.modifiedDate());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = WaitingStatus.class, mode = EnumSource.Mode.EXCLUDE, names = {"PROGRESS"})
+    @DisplayName("웨이팅이 진행 상태가 아닌 경우 상세 정보를 조회할 때 웨이팅 순위는 조회되지 않는다.")
+    void findWaitingDetailsTest(WaitingStatus waitingStatus) {
+        //given
+        var waitingId = 1L;
+
+        var shopDetails = DataInitializerFactory.shopDetails();
+        var waitingPeople = DataInitializerFactory.waitingPeople(2, 0);
+        var waitingDetails = DataInitializerFactory.waitingDetails(shopDetails, waitingStatus, waitingPeople);
+
+        given(waitingRepository.findByWaitingDetails(any(Long.class))).willReturn(Optional.ofNullable(waitingDetails));
+
+        //when
+        var waitingDetailsResponse = waitingService.findWaitingDetails(waitingId);
+
+        //then
+        verify(waitingRepository, times(1)).findByWaitingDetails(any(Long.class));
+        verify(waitingLine, never()).findRank(any(Long.class),
+                any(Long.class),
+                any(LocalDateTime.class));
+        assertThat(waitingDetailsResponse.shop().shopName()).isEqualTo(waitingDetails.shopName());
+        assertThat(waitingDetailsResponse.shop().shopType()).isEqualTo(waitingDetails.shopType());
+        assertThat(waitingDetailsResponse.shop().region()).isEqualTo(waitingDetails.region());
+        assertThat(waitingDetailsResponse.shop().shopDetails()).usingRecursiveComparison().isEqualTo(shopDetails);
+        assertThat(waitingDetailsResponse.waitingNumber()).isEqualTo(waitingDetails.waitingNumber());
+        assertThat(waitingDetailsResponse.waitingStatus()).isEqualTo(waitingStatus);
+        assertThat(waitingDetailsResponse.waitingPeople()).usingRecursiveComparison().isEqualTo(waitingPeople);
+        assertThat(waitingDetailsResponse.waitingRank()).isNull();
+        assertThat(waitingDetailsResponse.createdDate()).isEqualTo(waitingDetails.createdDate());
+        assertThat(waitingDetailsResponse.modifiedDate()).isEqualTo(waitingDetails.modifiedDate());
+    }
 }

--- a/src/test/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepositoryTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepositoryTest.java
@@ -1,0 +1,72 @@
+package com.mdh.devtable.waiting.infra.persistence;
+
+import com.mdh.devtable.DataInitializerFactory;
+import com.mdh.devtable.shop.infra.persistence.RegionRepository;
+import com.mdh.devtable.shop.infra.persistence.ShopRepository;
+import com.mdh.devtable.user.infra.persistence.UserRepository;
+import com.mdh.devtable.waiting.domain.ShopWaitingStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class WaitingRepositoryTest {
+
+    @Autowired
+    private WaitingRepository waitingRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ShopRepository shopRepository;
+
+    @Autowired
+    private RegionRepository regionRepository;
+
+    @Autowired
+    private ShopWaitingRepository shopWaitingRepository;
+
+    @Test
+    @DisplayName("웨이팅 아이디로 웨이팅 상세 정보를 가져온다.")
+    void findWaitingDetails() {
+        //given
+        var guest = DataInitializerFactory.guest();
+        var savedUser = userRepository.save(guest);
+
+        var region = DataInitializerFactory.region();
+        regionRepository.save(region);
+
+        var shopDetails = DataInitializerFactory.shopDetails();
+        var shopAddress = DataInitializerFactory.shopAddress();
+        var shop = DataInitializerFactory.shop(guest.getId(), shopDetails, region, shopAddress);
+        var savedShop = shopRepository.save(shop);
+
+        var shopWaiting = DataInitializerFactory.shopWaiting(savedUser.getId(), 20, 7, 2);
+        shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
+        var savedShopWaiting = shopWaitingRepository.save(shopWaiting);
+
+        var waitingPeople = DataInitializerFactory.waitingPeople(2, 0);
+        var waiting = DataInitializerFactory.waiting(savedUser.getId(), shopWaiting, waitingPeople);
+        var savedWaiting = waitingRepository.save(waiting);
+
+        //when
+        var waitingDetails = waitingRepository.findByWaitingDetails(savedWaiting.getId()).orElse(null);
+
+        //then
+        assertThat(waitingDetails.shopName()).isEqualTo(shop.getName());
+        assertThat(waitingDetails.region()).isEqualTo(region.getDistrict());
+        assertThat(waitingDetails.shopType()).isEqualTo(shop.getShopType());
+        assertThat(waitingDetails.shopDetails()).isEqualTo(shopDetails);
+        assertThat(waitingDetails.waitingNumber()).isEqualTo(waiting.getWaitingNumber());
+        assertThat(waitingDetails.waitingStatus()).isEqualTo(waiting.getWaitingStatus());
+        assertThat(waitingDetails.waitingPeople()).isEqualTo(waitingPeople);
+        assertThat(waitingDetails.createdDate()).isEqualTo(waiting.getCreatedDate());
+        assertThat(waitingDetails.modifiedDate()).isEqualTo(waiting.getModifiedDate());
+    }
+}

--- a/src/test/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepositoryTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.mdh.devtable.waiting.infra.persistence;
 
 import com.mdh.devtable.DataInitializerFactory;
+import com.mdh.devtable.global.config.JpaConfig;
 import com.mdh.devtable.shop.infra.persistence.RegionRepository;
 import com.mdh.devtable.shop.infra.persistence.ShopRepository;
 import com.mdh.devtable.user.infra.persistence.UserRepository;
@@ -8,16 +9,20 @@ import com.mdh.devtable.waiting.domain.ShopWaitingStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.time.temporal.ChronoUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 
-@SpringBootTest
-@Transactional
+@DataJpaTest
+@Import({JpaConfig.class})
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class WaitingRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepositoryTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepositoryTest.java
@@ -47,25 +47,26 @@ class WaitingRepositoryTest {
         var shop = DataInitializerFactory.shop(guest.getId(), shopDetails, region, shopAddress);
         var savedShop = shopRepository.save(shop);
 
-        var shopWaiting = DataInitializerFactory.shopWaiting(savedUser.getId(), 20, 7, 2);
+        var shopWaiting = DataInitializerFactory.shopWaiting(savedShop.getId(), 20, 7, 2);
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
         var savedShopWaiting = shopWaitingRepository.save(shopWaiting);
 
         var waitingPeople = DataInitializerFactory.waitingPeople(2, 0);
-        var waiting = DataInitializerFactory.waiting(savedUser.getId(), shopWaiting, waitingPeople);
+        var waiting = DataInitializerFactory.waiting(savedUser.getId(), savedShopWaiting, waitingPeople);
         var savedWaiting = waitingRepository.save(waiting);
 
         //when
         var waitingDetails = waitingRepository.findByWaitingDetails(savedWaiting.getId()).orElse(null);
 
         //then
+        assertThat(waitingDetails.shopId()).isEqualTo(shop.getId());
         assertThat(waitingDetails.shopName()).isEqualTo(shop.getName());
         assertThat(waitingDetails.region()).isEqualTo(region.getDistrict());
         assertThat(waitingDetails.shopType()).isEqualTo(shop.getShopType());
-        assertThat(waitingDetails.shopDetails()).isEqualTo(shopDetails);
+        assertThat(waitingDetails.shopDetails()).usingRecursiveComparison().isEqualTo(shopDetails);
         assertThat(waitingDetails.waitingNumber()).isEqualTo(waiting.getWaitingNumber());
         assertThat(waitingDetails.waitingStatus()).isEqualTo(waiting.getWaitingStatus());
-        assertThat(waitingDetails.waitingPeople()).isEqualTo(waitingPeople);
+        assertThat(waitingDetails.waitingPeople()).usingRecursiveComparison().isEqualTo(waitingPeople);
         assertThat(waitingDetails.createdDate()).isEqualTo(waiting.getCreatedDate());
         assertThat(waitingDetails.modifiedDate()).isEqualTo(waiting.getModifiedDate());
     }

--- a/src/test/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepositoryTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepositoryTest.java
@@ -11,7 +11,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.temporal.ChronoUnit;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 
 @SpringBootTest
 @Transactional
@@ -67,7 +70,7 @@ class WaitingRepositoryTest {
         assertThat(waitingDetails.waitingNumber()).isEqualTo(waiting.getWaitingNumber());
         assertThat(waitingDetails.waitingStatus()).isEqualTo(waiting.getWaitingStatus());
         assertThat(waitingDetails.waitingPeople()).usingRecursiveComparison().isEqualTo(waitingPeople);
-        assertThat(waitingDetails.createdDate()).isEqualTo(waiting.getCreatedDate());
-        assertThat(waitingDetails.modifiedDate()).isEqualTo(waiting.getModifiedDate());
+        assertThat(waitingDetails.createdDate()).isCloseTo(waiting.getCreatedDate(), within(1, ChronoUnit.SECONDS));
+        assertThat(waitingDetails.modifiedDate()).isCloseTo(waiting.getModifiedDate(), within(1, ChronoUnit.SECONDS));
     }
 }

--- a/src/test/java/com/mdh/devtable/waiting/presentation/UserWaitingControllerTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/presentation/UserWaitingControllerTest.java
@@ -1,7 +1,12 @@
 package com.mdh.devtable.waiting.presentation;
 
+import com.mdh.devtable.DataInitializerFactory;
 import com.mdh.devtable.RestDocsSupport;
+import com.mdh.devtable.shop.ShopType;
 import com.mdh.devtable.waiting.application.WaitingService;
+import com.mdh.devtable.waiting.application.dto.ShopWaitingResponse;
+import com.mdh.devtable.waiting.application.dto.WaitingDetailsResponse;
+import com.mdh.devtable.waiting.domain.WaitingStatus;
 import com.mdh.devtable.waiting.presentation.dto.WaitingCreateRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,13 +18,13 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 
+import java.time.LocalDateTime;
 import java.util.stream.Stream;
 
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -174,6 +179,69 @@ class UserWaitingControllerTest extends RestDocsSupport {
                                 fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("상태 코드"),
                                 fieldWithPath("data").type(JsonFieldType.NULL).description("응답 바디(비어있음)"),
                                 fieldWithPath("serverDateTime").type(JsonFieldType.STRING).description("생성된 서버 시간")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("웨이팅을 상세 조회한다.")
+    void findWaitingDetailsTest() throws Exception {
+        //given
+        var shopDetails = DataInitializerFactory.shopDetails();
+        var shopWaitingResponse = new ShopWaitingResponse("김밥천국", ShopType.KOREAN, "강남구", shopDetails);
+        var waitingPeople = DataInitializerFactory.waitingPeople(2, 0);
+        var waitingDetailsResponse = new WaitingDetailsResponse(shopWaitingResponse,
+                85,
+                5,
+                WaitingStatus.PROGRESS,
+                waitingPeople,
+                LocalDateTime.of(2023, 9, 8, 16, 0, 0),
+                LocalDateTime.of(2023, 9, 8, 16, 0, 0));
+        var waitingId = 1L;
+        when(waitingService.findWaitingDetails(waitingId)).thenReturn(waitingDetailsResponse);
+
+        //when & then
+        mockMvc.perform(get("/api/customer/v1/waitings/{waitingId}", waitingId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value("200"))
+                .andExpect(jsonPath("$.data.shop.shopName").value(shopWaitingResponse.shopName()))
+                .andExpect(jsonPath("$.data.shop.shopType").value("KOREAN"))
+                .andExpect(jsonPath("$.data.shop.region").value(shopWaitingResponse.region()))
+                .andExpect(jsonPath("$.data.shop.shopDetails.url").value(shopWaitingResponse.shopDetails().getUrl()))
+                .andExpect(jsonPath("$.data.shop.shopDetails.phoneNumber").value(shopDetails.getPhoneNumber()))
+                .andExpect(jsonPath("$.data.shop.shopDetails.introduce").value(shopDetails.getIntroduce()))
+                .andExpect(jsonPath("$.data.shop.shopDetails.openingHours").value(shopDetails.getOpeningHours()))
+                .andExpect(jsonPath("$.data.shop.shopDetails.holiday").value(shopDetails.getHoliday()))
+                .andExpect(jsonPath("$.data.shop.shopDetails.info").value(shopDetails.getInfo()))
+                .andExpect(jsonPath("$.data.waitingNumber").value(85))
+                .andExpect(jsonPath("$.data.waitingRank").value(5))
+                .andExpect(jsonPath("$.data.waitingStatus").value("PROGRESS"))
+                .andExpect(jsonPath("$.data.waitingPeople.adultCount").value(waitingPeople.getAdultCount()))
+                .andExpect(jsonPath("$.data.waitingPeople.childCount").value(waitingPeople.getChildCount()))
+                .andExpect(jsonPath("$.data.createdDate").value("2023-09-08T16:00:00"))
+                .andExpect(jsonPath("$.data.modifiedDate").value("2023-09-08T16:00:00"))
+                .andExpect(jsonPath("$.serverDateTime").exists())
+                .andDo(document("waiting-detail-find",
+                        responseFields(
+                                fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("상태 코드"),
+                                fieldWithPath("data.shop.shopName").type(JsonFieldType.STRING).description("상점 이름"),
+                                fieldWithPath("data.shop.shopType").type(JsonFieldType.STRING).description("상점 타입"),
+                                fieldWithPath("data.shop.region").type(JsonFieldType.STRING).description("상점 지역"),
+                                fieldWithPath("data.shop.shopDetails.url").type(JsonFieldType.STRING).description("상점 URL"),
+                                fieldWithPath("data.shop.shopDetails.phoneNumber").type(JsonFieldType.STRING).description("상점 전화번호"),
+                                fieldWithPath("data.shop.shopDetails.introduce").type(JsonFieldType.STRING).description("상점 소개"),
+                                fieldWithPath("data.shop.shopDetails.openingHours").type(JsonFieldType.STRING).description("상점 영업 시간"),
+                                fieldWithPath("data.shop.shopDetails.holiday").type(JsonFieldType.STRING).description("상점 휴무일"),
+                                fieldWithPath("data.shop.shopDetails.info").type(JsonFieldType.STRING).description("상점 간단 소개"),
+                                fieldWithPath("data.waitingNumber").type(JsonFieldType.NUMBER).description("대기 번호"),
+                                fieldWithPath("data.waitingRank").type(JsonFieldType.NUMBER).description("대기 순위"),
+                                fieldWithPath("data.waitingStatus").type(JsonFieldType.STRING).description("대기 상태"),
+                                fieldWithPath("data.waitingPeople.adultCount").type(JsonFieldType.NUMBER).description("어른 인원 수"),
+                                fieldWithPath("data.waitingPeople.childCount").type(JsonFieldType.NUMBER).description("유아 인원 수"),
+                                fieldWithPath("data.createdDate").type(JsonFieldType.STRING).description("생성일"),
+                                fieldWithPath("data.modifiedDate").type(JsonFieldType.STRING).description("수정일"),
+                                fieldWithPath("serverDateTime").type(JsonFieldType.STRING).description("서버 시간")
                         )
                 ));
     }


### PR DESCRIPTION
## 🖊️ 1. Changes

- repository에 매장과 조인하여 웨이팅 상세 정보 dto를 Optional로 반환하는 메서드 추가했습니다.
- 웨이팅이 진행 상태일 경우 웨이팅 순위는 null로 반환하도록 했습니다.

## 🖼️ 2. Screenshot
- 웨이팅 서비스 테스트
![waiting service test](https://github.com/prgrms-be-devcourse/BE-04-DevTable/assets/83766322/2470354d-3d4f-4c0f-9485-ecc219ca97c3)

- 웨이팅 컨트롤러 테스트
![waiting detail rest docs](https://github.com/prgrms-be-devcourse/BE-04-DevTable/assets/83766322/f8eaeadd-0748-464f-a0a6-13b342ece2d1)

## ❗️ 3. Issues

1. 로컬에서는 LocalDateTime에 대한 검증이 잘 동작 했지만, github action에서는 실패하였습니다. 
이유는 소수 초를 가지고 있는 LocalDateTime과 달리 **MySQL**의 **DATETIME**은 소수 초를 버린다고 합니다. 
따라서 데이터베이스에 가져온 날짜/시간을 검증할 때 초 단위 내에서 검증하는 것만으로도 충분하다고 합니다.
```java
// 실패한 코드
assertThat(waitingDetails.createdDate()).isEqualTo(waiting.getCreatedDate());
// 성공한 코드
assertThat(waitingDetails.createdDate()).isCloseTo(waiting.getCreatedDate(), within(1, ChronoUnit.SECONDS));
```
3. 

## 😌 4. To Reviewer

-

## ✅ 5. Plans
- [x] - service의 단위 테스트는 이후에 진행하겠습니다.
- [ ] - 
