### PR TITLE
[MDH-59] feat : 점주가 갖고 있는 매장의 웨이팅 조회 서비스, 테스트 코드 작성

### DIFF
--- a/src/main/java/com/mdh/devtable/ownerwaiting/application/OwnerWaitingService.java
+++ b/src/main/java/com/mdh/devtable/ownerwaiting/application/OwnerWaitingService.java
@@ -3,10 +3,13 @@ package com.mdh.devtable.ownerwaiting.application;
 import com.mdh.devtable.ownerwaiting.infra.persistence.OwnerWaitingRepository;
 import com.mdh.devtable.ownerwaiting.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
 import com.mdh.devtable.ownerwaiting.presentaion.dto.OwnerWaitingStatusChangeRequest;
+import com.mdh.devtable.ownerwaiting.presentaion.dto.WaitingInfoRequestForOwner;
+import com.mdh.devtable.ownerwaiting.presentaion.dto.WaitingInfoResponseForOwner;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 
 @Service
@@ -27,5 +30,10 @@ public class OwnerWaitingService {
         var waiting = ownerWaitingRepository.findWaitingByWaitingId(waitingId)
                 .orElseThrow(() -> new NoSuchElementException("웨이팅 조회 결과가 없습니다."));
         waiting.changeWaitingStatus(request.waitingStatus());
+    }
+
+    @Transactional(readOnly = true)
+    public List<WaitingInfoResponseForOwner> findWaitingByShopIdAndWaitingStatus(Long ownerId, WaitingInfoRequestForOwner request) {
+        return ownerWaitingRepository.findWaitingByOwnerIdAndWaitingStatus(ownerId, request.waitingStatus());
     }
 }

--- a/src/main/java/com/mdh/devtable/ownerwaiting/infra/persistence/OwnerWaitingRepository.java
+++ b/src/main/java/com/mdh/devtable/ownerwaiting/infra/persistence/OwnerWaitingRepository.java
@@ -1,9 +1,12 @@
 package com.mdh.devtable.ownerwaiting.infra.persistence;
 
 
+import com.mdh.devtable.ownerwaiting.presentaion.dto.WaitingInfoResponseForOwner;
 import com.mdh.devtable.waiting.domain.ShopWaiting;
 import com.mdh.devtable.waiting.domain.Waiting;
+import com.mdh.devtable.waiting.domain.WaitingStatus;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface OwnerWaitingRepository {
@@ -11,5 +14,7 @@ public interface OwnerWaitingRepository {
     Optional<ShopWaiting> findShopWaitingByShopId(Long shopId);
 
     Optional<Waiting> findWaitingByWaitingId(Long waitingId);
+
+    List<WaitingInfoResponseForOwner> findWaitingByOwnerIdAndWaitingStatus(Long ownerId, WaitingStatus waitingStatus);
 
 }

--- a/src/main/java/com/mdh/devtable/ownerwaiting/infra/persistence/OwnerWaitingRepositoryImpl.java
+++ b/src/main/java/com/mdh/devtable/ownerwaiting/infra/persistence/OwnerWaitingRepositoryImpl.java
@@ -1,12 +1,15 @@
 package com.mdh.devtable.ownerwaiting.infra.persistence;
 
+import com.mdh.devtable.ownerwaiting.presentaion.dto.WaitingInfoResponseForOwner;
 import com.mdh.devtable.waiting.domain.ShopWaiting;
 import com.mdh.devtable.waiting.domain.Waiting;
+import com.mdh.devtable.waiting.domain.WaitingStatus;
 import com.mdh.devtable.waiting.infra.persistence.ShopWaitingRepository;
 import com.mdh.devtable.waiting.infra.persistence.WaitingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -24,5 +27,10 @@ public class OwnerWaitingRepositoryImpl implements OwnerWaitingRepository {
     @Override
     public Optional<Waiting> findWaitingByWaitingId(Long waitingId) {
         return waitingRepository.findById(waitingId);
+    }
+
+    @Override
+    public List<WaitingInfoResponseForOwner> findWaitingByOwnerIdAndWaitingStatus(Long ownerId, WaitingStatus waitingStatus) {
+        return waitingRepository.findWaitingByOwnerIdAndWaitingStatus(ownerId, waitingStatus);
     }
 }

--- a/src/main/java/com/mdh/devtable/ownerwaiting/presentaion/dto/WaitingInfoRequestForOwner.java
+++ b/src/main/java/com/mdh/devtable/ownerwaiting/presentaion/dto/WaitingInfoRequestForOwner.java
@@ -1,0 +1,8 @@
+package com.mdh.devtable.ownerwaiting.presentaion.dto;
+
+import com.mdh.devtable.waiting.domain.WaitingStatus;
+
+public record WaitingInfoRequestForOwner(
+        WaitingStatus waitingStatus
+) {
+}

--- a/src/main/java/com/mdh/devtable/ownerwaiting/presentaion/dto/WaitingInfoResponseForOwner.java
+++ b/src/main/java/com/mdh/devtable/ownerwaiting/presentaion/dto/WaitingInfoResponseForOwner.java
@@ -1,0 +1,7 @@
+package com.mdh.devtable.ownerwaiting.presentaion.dto;
+
+public record WaitingInfoResponseForOwner(
+        int waitingNumber,
+        String phoneNumber
+) {
+}

--- a/src/main/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepository.java
+++ b/src/main/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepository.java
@@ -1,14 +1,27 @@
 package com.mdh.devtable.waiting.infra.persistence;
 
+import com.mdh.devtable.ownerwaiting.presentaion.dto.WaitingInfoResponseForOwner;
 import com.mdh.devtable.waiting.domain.Waiting;
+import com.mdh.devtable.waiting.domain.WaitingStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface WaitingRepository extends JpaRepository<Waiting, Long> {
 
     @Query("select w from Waiting w where w.waitingStatus = 'PROGRESS' and w.userId = :userId")
     Optional<Waiting> findByProgressWaiting(@Param("userId") Long userId);
+
+    @Query("""
+            SELECT new com.mdh.devtable.ownerwaiting.presentaion.dto.WaitingInfoResponseForOwner(w.waitingNumber, u.email)
+            FROM Waiting w
+            JOIN User u ON w.userId = u.id
+            JOIN Shop s ON w.shopWaiting.shopId = s.id
+            WHERE s.userId = :ownerId AND
+                  w.waitingStatus = :waitingStatus
+            """)
+    List<WaitingInfoResponseForOwner> findWaitingByOwnerIdAndWaitingStatus(@Param("ownerId") Long ownerId, @Param("waitingStatus") WaitingStatus waitingStatus);
 }

--- a/src/test/java/com/mdh/devtable/ownerwaiting/application/OwnerWaitingServiceTest.java
+++ b/src/test/java/com/mdh/devtable/ownerwaiting/application/OwnerWaitingServiceTest.java
@@ -4,6 +4,8 @@ import com.mdh.devtable.DataInitializerFactory;
 import com.mdh.devtable.ownerwaiting.infra.persistence.OwnerWaitingRepository;
 import com.mdh.devtable.ownerwaiting.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
 import com.mdh.devtable.ownerwaiting.presentaion.dto.OwnerWaitingStatusChangeRequest;
+import com.mdh.devtable.ownerwaiting.presentaion.dto.WaitingInfoRequestForOwner;
+import com.mdh.devtable.ownerwaiting.presentaion.dto.WaitingInfoResponseForOwner;
 import com.mdh.devtable.waiting.domain.ShopWaitingStatus;
 import com.mdh.devtable.waiting.domain.WaitingStatus;
 import org.assertj.core.api.Assertions;
@@ -15,6 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static org.mockito.BDDMockito.given;
@@ -69,5 +72,21 @@ class OwnerWaitingServiceTest {
         // then
         verify(ownerWaitingRepository, times(1)).findWaitingByWaitingId(waitingId);
         Assertions.assertThat(WaitingStatus.valueOf(status)).isEqualTo(waiting.getWaitingStatus());
+    }
+
+    @DisplayName("점주 id, 웨이팅 상태로 웨이팅을 조회할 수 있다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"PROGRESS", "CANCEL", "NO_SHOW", "VISITED"})
+    void findWaitingByShopIdAndWaitingStatus(String status) {
+        var ownerId = 1L;
+        var response = Collections.singletonList(new WaitingInfoResponseForOwner(1, "test"));
+        var request = new WaitingInfoRequestForOwner(WaitingStatus.valueOf(status));
+        given(ownerWaitingRepository.findWaitingByOwnerIdAndWaitingStatus(ownerId, WaitingStatus.valueOf(status))).willReturn(response);
+
+        //when
+        var result = ownerWaitingService.findWaitingByShopIdAndWaitingStatus(ownerId, request);
+
+        //then
+        Assertions.assertThat(result).isEqualTo(response);
     }
 }

--- a/src/test/java/com/mdh/devtable/ownerwaiting/application/OwnerWaitingServiceTest.java
+++ b/src/test/java/com/mdh/devtable/ownerwaiting/application/OwnerWaitingServiceTest.java
@@ -1,9 +1,11 @@
 package com.mdh.devtable.ownerwaiting.application;
 
+import com.mdh.devtable.DataInitializerFactory;
 import com.mdh.devtable.ownerwaiting.infra.persistence.OwnerWaitingRepository;
 import com.mdh.devtable.ownerwaiting.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
 import com.mdh.devtable.ownerwaiting.presentaion.dto.OwnerWaitingStatusChangeRequest;
-import com.mdh.devtable.waiting.domain.*;
+import com.mdh.devtable.waiting.domain.ShopWaitingStatus;
+import com.mdh.devtable.waiting.domain.WaitingStatus;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,13 +37,7 @@ class OwnerWaitingServiceTest {
     void changeShopWaitingStatus(String status) {
         //given
         var shopId = 1L;
-        var shopWaiting = ShopWaiting
-                .builder()
-                .shopId(shopId)
-                .maximumWaitingPeople(2)
-                .minimumWaitingPeople(1)
-                .maximumWaiting(10)
-                .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, 2, 1, 1);
         var request = new OwnerShopWaitingStatusChangeRequest(ShopWaitingStatus.valueOf(status));
         given(ownerWaitingRepository.findShopWaitingByShopId(shopId)).willReturn(Optional.of(shopWaiting));
 
@@ -58,20 +54,11 @@ class OwnerWaitingServiceTest {
     @ValueSource(strings = {"PROGRESS", "CANCEL", "NO_SHOW", "VISITED"})
     void changeWaitingStatus(String status) {
         //given
-        var shopWaiting = ShopWaiting
-                .builder()
-                .shopId(1L)
-                .maximumWaitingPeople(2)
-                .minimumWaitingPeople(1)
-                .maximumWaiting(10)
-                .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(1L, 2, 1, 1);
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
         var waitingId = 1L;
-        var waiting = Waiting.builder()
-                .shopWaiting(shopWaiting)
-                .userId(1L)
-                .waitingPeople(new WaitingPeople(1, 0))
-                .build();
+        var waitingPeople = DataInitializerFactory.waitingPeople(1, 0);
+        var waiting = DataInitializerFactory.waiting(1L, shopWaiting, waitingPeople);
 
         var request = new OwnerWaitingStatusChangeRequest(WaitingStatus.valueOf(status));
         given(ownerWaitingRepository.findWaitingByWaitingId(waitingId)).willReturn(Optional.of(waiting));

--- a/src/test/java/com/mdh/devtable/ownerwaiting/infra/persistence/OwnerWaitingRepositoryTest.java
+++ b/src/test/java/com/mdh/devtable/ownerwaiting/infra/persistence/OwnerWaitingRepositoryTest.java
@@ -1,0 +1,76 @@
+package com.mdh.devtable.ownerwaiting.infra.persistence;
+
+import com.mdh.devtable.DataInitializerFactory;
+import com.mdh.devtable.global.config.JpaConfig;
+import com.mdh.devtable.shop.infra.persistence.RegionRepository;
+import com.mdh.devtable.shop.infra.persistence.ShopRepository;
+import com.mdh.devtable.user.infra.persistence.UserRepository;
+import com.mdh.devtable.waiting.domain.ShopWaitingStatus;
+import com.mdh.devtable.waiting.domain.WaitingStatus;
+import com.mdh.devtable.waiting.infra.persistence.ShopWaitingRepository;
+import com.mdh.devtable.waiting.infra.persistence.WaitingRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({JpaConfig.class})
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class OwnerWaitingRepositoryTest {
+
+    @Autowired
+    private WaitingRepository waitingRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ShopWaitingRepository shopWaitingRepository;
+
+    @Autowired
+    private ShopRepository shopRepository;
+
+    @Autowired
+    private RegionRepository regionRepository;
+
+    @DisplayName("점주 id, 웨이팅 상태로 웨이팅을 조회할 수 있다.")
+    @Test
+    void findWaitingByOwnerIdAndWaitingStatus() {
+        //given
+        var owner = DataInitializerFactory.owner();
+        userRepository.save(owner);
+
+        var region = DataInitializerFactory.region();
+        regionRepository.save(region);
+
+        var shopDetails = DataInitializerFactory.shopDetails();
+        var shopAddress = DataInitializerFactory.shopAddress();
+        var shop = DataInitializerFactory.shop(owner.getId(), shopDetails, region, shopAddress);
+        shopRepository.save(shop);
+
+        var shopWaiting = DataInitializerFactory.shopWaiting(shop.getId(), 30, 8, 2);
+        shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
+        shopWaiting.updateChildEnabled(true);
+        shopWaitingRepository.save(shopWaiting);
+
+        var waitingPeople = DataInitializerFactory.waitingPeople(2, 3);
+        var waiting = DataInitializerFactory.waiting(owner.getId(), shopWaiting, waitingPeople);
+        waiting.changeWaitingStatus(WaitingStatus.PROGRESS);
+        waitingRepository.save(waiting);
+
+        //when
+        var result = waitingRepository.findWaitingByOwnerIdAndWaitingStatus(owner.getId(), WaitingStatus.PROGRESS);
+
+        //then
+        assertThat(result).isNotEmpty();
+        assertThat(result.get(0).phoneNumber()).isEqualTo(owner.getEmail()); // email을 나중에 phoneNumber로 리팩토링 해야함
+        assertThat(result.get(0).waitingNumber()).isEqualTo(waiting.getWaitingNumber());
+    }
+}

--- a/src/test/java/com/mdh/devtable/shop/ShopTest.java
+++ b/src/test/java/com/mdh/devtable/shop/ShopTest.java
@@ -1,5 +1,6 @@
 package com.mdh.devtable.shop;
 
+import com.mdh.devtable.DataInitializerFactory;
 import org.hibernate.AssertionFailure;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -15,38 +16,12 @@ class ShopTest {
     void shopConstructorTest() {
         // given
         var userId = 1L;
-
-        var shopDetails = ShopDetails.builder()
-                .url("www.example.com")
-                .holiday("일요일")
-                .openingHours("11시")
-                .phoneNumber("01012345678")
-                .info("정보")
-                .introduce("introduce")
-                .build();
-
-        var shopAddress = ShopAddress.builder()
-                .address("가로수길 31-3, 301호")
-                .zipcode("11111")
-                .latitude("123.123")
-                .longitude("123.123")
-                .build();
-
-        var region = Region.builder()
-                .city("서울시")
-                .district("강남구")
-                .build();
+        var shopDetails = DataInitializerFactory.shopDetails();
+        var shopAddress = DataInitializerFactory.shopAddress();
+        var region = DataInitializerFactory.region();
 
         // when
-        Shop shop = Shop.builder()
-                .userId(userId)
-                .name("Test Shop")
-                .description("This is a test shop")
-                .shopType(ShopType.KOREAN) // 가정: ShopType 열거형에 TYPE1이 있음
-                .shopDetails(shopDetails)
-                .shopAddress(shopAddress)
-                .region(region)
-                .build();
+        var shop = DataInitializerFactory.shop(userId, shopDetails, region, shopAddress);
 
         // then
         assertThat(shop)
@@ -58,9 +33,9 @@ class ShopTest {
                         Shop::getShopAddress,
                         Shop::getRegion)
                 .containsExactly(0,
-                        "Test Shop",
-                        "This is a test shop",
-                        ShopType.KOREAN,
+                        "가게 이름",
+                        "가게의 간단한 설명",
+                        ShopType.AMERICAN,
                         shopDetails,
                         shopAddress,
                         region);
@@ -80,36 +55,10 @@ class ShopTest {
         // given
         var userId = 1L;
 
-        var shopDetails = ShopDetails.builder()
-                .url("www.example.com")
-                .holiday("일요일")
-                .openingHours("11시")
-                .phoneNumber("01012345678")
-                .info("정보")
-                .introduce("introduce")
-                .build();
-
-        var shopAddress = ShopAddress.builder()
-                .address("잠실로 62, 302동 202호")
-                .zipcode("11111")
-                .latitude("123.123")
-                .longitude("123.123")
-                .build();
-
-        var region = Region.builder()
-                .city("서울시")
-                .district("강남구")
-                .build();
-
-        Shop shop = Shop.builder()
-                .userId(1L)
-                .name("Test Shop")
-                .description("This is a test shop")
-                .shopType(ShopType.KOREAN) // 가정: ShopType 열거형에 TYPE1이 있음
-                .shopDetails(shopDetails)
-                .shopAddress(shopAddress)
-                .region(region)
-                .build();
+        var shopDetails = DataInitializerFactory.shopDetails();
+        var shopAddress = DataInitializerFactory.shopAddress();
+        var region = DataInitializerFactory.region();
+        var shop = DataInitializerFactory.shop(userId, shopDetails, region, shopAddress);
 
         String changeName = "changedName";
         String changeDescription = "changedDescription";
@@ -176,37 +125,10 @@ class ShopTest {
     void increaseBookMarks() {
         // given
         var userId = 1L;
-
-        var shopDetails = ShopDetails.builder()
-                .url("www.example.com")
-                .holiday("일요일")
-                .openingHours("11시")
-                .phoneNumber("01012345678")
-                .info("정보")
-                .introduce("introduce")
-                .build();
-
-        var shopAddress = ShopAddress.builder()
-                .address("서울시 강남구")
-                .zipcode("11111")
-                .latitude("123.123")
-                .longitude("123.123")
-                .build();
-
-        var region = Region.builder()
-                .city("서울시")
-                .district("강남구")
-                .build();
-
-        Shop shop = Shop.builder()
-                .userId(1L)
-                .name("Test Shop")
-                .description("This is a test shop")
-                .shopType(ShopType.KOREAN)
-                .shopDetails(shopDetails)
-                .shopAddress(shopAddress)
-                .region(region)
-                .build();
+        var shopDetails = DataInitializerFactory.shopDetails();
+        var shopAddress = DataInitializerFactory.shopAddress();
+        var region = DataInitializerFactory.region();
+        var shop = DataInitializerFactory.shop(userId, shopDetails, region, shopAddress);
 
         // when
         shop.increaseBookmarkCount();
@@ -220,37 +142,10 @@ class ShopTest {
     void decreaseBookMarks() {
         // given
         var userId = 1L;
-
-        var shopDetails = ShopDetails.builder()
-                .url("www.example.com")
-                .holiday("일요일")
-                .openingHours("11시")
-                .phoneNumber("01012345678")
-                .info("정보")
-                .introduce("introduce")
-                .build();
-
-        var shopAddress = ShopAddress.builder()
-                .address("서울시 강남구")
-                .zipcode("11111")
-                .latitude("123.123")
-                .longitude("123.123")
-                .build();
-
-        var region = Region.builder()
-                .city("서울시")
-                .district("강남구")
-                .build();
-
-        Shop shop = Shop.builder()
-                .userId(1L)
-                .name("Test Shop")
-                .description("This is a test shop")
-                .shopType(ShopType.KOREAN) // 가정: ShopType 열거형에 TYPE1이 있음
-                .shopDetails(shopDetails)
-                .shopAddress(shopAddress)
-                .region(region)
-                .build();
+        var shopDetails = DataInitializerFactory.shopDetails();
+        var shopAddress = DataInitializerFactory.shopAddress();
+        var region = DataInitializerFactory.region();
+        var shop = DataInitializerFactory.shop(userId, shopDetails, region, shopAddress);
 
         // when
         shop.increaseBookmarkCount();
@@ -265,39 +160,12 @@ class ShopTest {
     void bookMarkThrowsExceptionWhenBookMarkCountisZero() {
         // given
         var userId = 1L;
+        var shopDetails = DataInitializerFactory.shopDetails();
+        var shopAddress = DataInitializerFactory.shopAddress();
+        var region = DataInitializerFactory.region();
+        var shop = DataInitializerFactory.shop(userId, shopDetails, region, shopAddress);
 
-        var shopDetails = ShopDetails.builder()
-                .url("www.example.com")
-                .holiday("일요일")
-                .openingHours("11시")
-                .phoneNumber("01012345678")
-                .info("정보")
-                .introduce("introduce")
-                .build();
-
-        var shopAddress = ShopAddress.builder()
-                .address("서울시 강남구")
-                .zipcode("11111")
-                .latitude("123.123")
-                .longitude("123.123")
-                .build();
-
-        var region = Region.builder()
-                .city("서울시")
-                .district("강남구")
-                .build();
-
-        Shop shop = Shop.builder()
-                .userId(1L)
-                .name("Test Shop")
-                .description("This is a test shop")
-                .shopType(ShopType.KOREAN)
-                .shopDetails(shopDetails)
-                .shopAddress(shopAddress)
-                .region(region)
-                .build();
-
-        // when&then
+        // when & then
         assertThatThrownBy(shop::decreaseBookmarkCount)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("북마크 개수가 0 일 때 북마크 개수를 줄이는 것은 불가능합니다.");

--- a/src/test/java/com/mdh/devtable/user/application/UserServiceTest.java
+++ b/src/test/java/com/mdh/devtable/user/application/UserServiceTest.java
@@ -1,25 +1,27 @@
 package com.mdh.devtable.user.application;
 
+import com.mdh.devtable.user.domain.User;
 import com.mdh.devtable.user.infra.persistence.UserRepository;
 import com.mdh.devtable.user.presentation.dto.SignUpRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
-@SpringBootTest
-@Transactional
-@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
 public class UserServiceTest {
 
-    @Autowired
+    @InjectMocks
     private UserService userService;
 
-    @Autowired
+    @Mock
     private UserRepository userRepository;
 
     @Test
@@ -28,15 +30,12 @@ public class UserServiceTest {
         // given
         var signUpRequest = new SignUpRequest("test@example.com", "password123", "password123");
         var expectedUser = signUpRequest.toEntity();
+        given(userRepository.save(any(User.class))).willReturn(expectedUser);
 
         // when
         userService.signUp(signUpRequest);
 
         // then
-        var actualUser = userRepository.findByEmail("test@example.com").orElse(null);
-        assertThat(actualUser).isNotNull();
-        assertThat(actualUser.getEmail()).isEqualTo(expectedUser.getEmail());
-        assertThat(actualUser.getRole()).isEqualTo(expectedUser.getRole());
-        assertThat(actualUser.getPassword()).isEqualTo(expectedUser.getPassword());
+        verify(userRepository, times(1)).save(any(User.class));
     }
 }

--- a/src/test/java/com/mdh/devtable/user/domain/UserTest.java
+++ b/src/test/java/com/mdh/devtable/user/domain/UserTest.java
@@ -1,6 +1,7 @@
 package com.mdh.devtable.user.domain;
 
 
+import com.mdh.devtable.DataInitializerFactory;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,14 +11,8 @@ class UserTest {
     @Test
     @DisplayName("유저를 생성할 수 있다.")
     void couldCreateUser() {
-        // given
-
-        // when
-        var user = User.builder()
-                .email("test@example.com")
-                .role(Role.GUEST)
-                .password("password123")
-                .build();
+        // given & when
+        var user = DataInitializerFactory.guest();
 
         // then
         Assertions.assertThat(user).isNotNull();

--- a/src/test/java/com/mdh/devtable/waiting/ShopWaitingTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/ShopWaitingTest.java
@@ -1,5 +1,6 @@
 package com.mdh.devtable.waiting;
 
+import com.mdh.devtable.DataInitializerFactory;
 import com.mdh.devtable.waiting.domain.ShopWaiting;
 import com.mdh.devtable.waiting.domain.ShopWaitingStatus;
 import org.junit.jupiter.api.DisplayName;
@@ -22,13 +23,7 @@ class ShopWaitingTest {
         var maximumWaiting = 10;
 
         //when
-        var shopWaiting = ShopWaiting
-                .builder()
-                .shopId(shopId)
-                .maximumWaitingPeople(2)
-                .minimumWaitingPeople(1)
-                .maximumWaiting(maximumWaiting)
-                .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, 2, 1);
 
         //then
         assertThat(shopWaiting.getShopId()).isEqualTo(shopId);
@@ -60,11 +55,7 @@ class ShopWaitingTest {
         var shopId = 1L;
         var maximumWaiting = 10;
 
-        var shopWaiting = ShopWaiting
-                .builder()
-                .shopId(shopId)
-                .maximumWaiting(maximumWaiting)
-                .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, 2, 1);
 
         //when
         shopWaiting.changeShopWaitingStatus(shopWaitingStatus);
@@ -80,11 +71,7 @@ class ShopWaitingTest {
         var shopId = 1L;
         var maximumWaiting = 10;
 
-        var shopWaiting = ShopWaiting
-                .builder()
-                .shopId(shopId)
-                .maximumWaiting(maximumWaiting)
-                .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, 2, 1);
 
         //when & then
         assertThatThrownBy(() -> shopWaiting.changeShopWaitingStatus(shopWaiting.getShopWaitingStatus()))
@@ -100,11 +87,7 @@ class ShopWaitingTest {
         var shopId = 1L;
         var maximumWaiting = 10;
 
-        var shopWaiting = ShopWaiting
-                .builder()
-                .shopId(shopId)
-                .maximumWaiting(maximumWaiting)
-                .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, 2, 1);
 
         //when
         shopWaiting.updateShopWaiting(changeMaximumWaiting);
@@ -120,11 +103,7 @@ class ShopWaitingTest {
         var shopId = 1L;
         var maximumWaiting = 10;
 
-        var shopWaiting = ShopWaiting
-                .builder()
-                .shopId(shopId)
-                .maximumWaiting(maximumWaiting)
-                .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, 2, 1);
 
         //when & then
         assertThatThrownBy(() -> shopWaiting.updateShopWaiting(0))
@@ -137,11 +116,9 @@ class ShopWaitingTest {
     void updateChildEnabled() {
         // given
         var shopId = 1L;
-        var maximumWaiting = 5;
-        var shopWaiting = ShopWaiting.builder()
-                .shopId(shopId)
-                .maximumWaiting(maximumWaiting)
-                .build();
+        var maximumWaiting = 10;
+
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, 2, 1);
 
         // when
         var newChildEnabled = true;
@@ -156,11 +133,9 @@ class ShopWaitingTest {
     void initShopWaitingCountTest() {
         //given
         var shopId = 1L;
-        var maximumWaiting = 5;
-        var shopWaiting = ShopWaiting.builder()
-                .shopId(shopId)
-                .maximumWaiting(maximumWaiting)
-                .build();
+        var maximumWaiting = 10;
+
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, 2, 1);
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
 
@@ -178,11 +153,9 @@ class ShopWaitingTest {
     void addShopWaitingCountExTest() {
         //given
         var shopId = 1L;
-        var maximumWaiting = 5;
-        var shopWaiting = ShopWaiting.builder()
-                .shopId(shopId)
-                .maximumWaiting(maximumWaiting)
-                .build();
+        var maximumWaiting = 10;
+
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, 2, 1);
 
         //when & then
         assertThatThrownBy(shopWaiting::addWaitingCount)

--- a/src/test/java/com/mdh/devtable/waiting/WaitingTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/WaitingTest.java
@@ -1,10 +1,7 @@
 package com.mdh.devtable.waiting;
 
-import com.mdh.devtable.waiting.domain.ShopWaiting;
-import com.mdh.devtable.waiting.domain.ShopWaitingStatus;
-import com.mdh.devtable.waiting.domain.Waiting;
-import com.mdh.devtable.waiting.domain.WaitingPeople;
-import com.mdh.devtable.waiting.domain.WaitingStatus;
+import com.mdh.devtable.DataInitializerFactory;
+import com.mdh.devtable.waiting.domain.*;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,40 +28,31 @@ class WaitingTest {
         var minimumWaitingPeople = 2;
         var maximumWaitingPeople = 5;
 
-        var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, maximumWaitingPeople, minimumWaitingPeople);
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
 
         //when
-        var waiting = Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .userId(userId)
-            .waitingPeople(waitingPeople)
-            .build();
+        var waiting = DataInitializerFactory.waiting(userId, shopWaiting, waitingPeople);
 
         //then
         assertThat(waiting)
-            .extracting(Waiting::getWaitingPeople,
-                Waiting::getShopWaiting,
-                Waiting::getUserId,
-                Waiting::getWaitingStatus,
-                Waiting::getPostponedCount)
-            .containsExactly(waitingPeople,
-                shopWaiting,
-                userId,
-                WaitingStatus.PROGRESS,
-                0);
+                .extracting(Waiting::getWaitingPeople,
+                        Waiting::getShopWaiting,
+                        Waiting::getUserId,
+                        Waiting::getWaitingStatus,
+                        Waiting::getPostponedCount)
+                .containsExactly(waitingPeople,
+                        shopWaiting,
+                        userId,
+                        WaitingStatus.PROGRESS,
+                        0);
     }
 
     static Stream<Arguments> waitingPeople() {
         return Stream.of(
-            Arguments.arguments(new WaitingPeople(2, 0)),
-            Arguments.arguments(new WaitingPeople(5, 0))
+                Arguments.arguments(DataInitializerFactory.waitingPeople(5, 0)),
+                Arguments.arguments(DataInitializerFactory.waitingPeople(5, 0))
         );
     }
 
@@ -79,26 +67,21 @@ class WaitingTest {
         var minimumWaitingPeople = 2;
         var maximumWaitingPeople = 5;
 
-        var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, maximumWaitingPeople, minimumWaitingPeople);
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
         shopWaiting.changeShopWaitingStatus(waitingStatus);
 
-        var waitingPeople = new WaitingPeople(2, 0);
+        var waitingPeople = DataInitializerFactory.waitingPeople(2, 0);
 
         //when & then
         assertThatThrownBy(() -> Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .userId(userId)
-            .waitingPeople(waitingPeople)
-            .build())
-            .isInstanceOf(IllegalStateException.class)
-            .hasMessage("매장이 오픈 상태가 아니면 웨이팅을 등록 할 수 없습니다.");
+                .shopWaiting(shopWaiting)
+                .userId(userId)
+                .waitingPeople(waitingPeople)
+                .build())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("매장이 오픈 상태가 아니면 웨이팅을 등록 할 수 없습니다.");
     }
 
     @Test
@@ -111,22 +94,14 @@ class WaitingTest {
         var minimumWaitingPeople = 2;
         var maximumWaitingPeople = 5;
 
-        var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, maximumWaitingPeople, minimumWaitingPeople);
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
 
-        var waitingPeople = new WaitingPeople(2, 0);
+        var waitingPeople = DataInitializerFactory.waitingPeople(2, 0);
 
-        var waiting = Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .userId(userId)
-            .waitingPeople(waitingPeople)
-            .build();
+        var waiting = DataInitializerFactory.waiting(userId, shopWaiting, waitingPeople);
+
         //when
         waiting.addPostponedCount();
 
@@ -146,30 +121,21 @@ class WaitingTest {
         var minimumWaitingPeople = 2;
         var maximumWaitingPeople = 5;
 
-        var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, maximumWaitingPeople, minimumWaitingPeople);
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
 
-        var waitingPeople = new WaitingPeople(2, 0);
+        var waitingPeople = DataInitializerFactory.waitingPeople(2, 0);
 
-        var waiting = Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .userId(userId)
-            .waitingPeople(waitingPeople)
-            .build();
+        var waiting = DataInitializerFactory.waiting(userId, shopWaiting, waitingPeople);
 
         //when
         waiting.changeWaitingStatus(waitingStatus);
 
         //then
         Assertions.assertThatThrownBy(waiting::addPostponedCount)
-            .isInstanceOf(IllegalStateException.class)
-            .hasMessage("진행 상태가 아닌 웨이팅 미루기는 불가능 합니다.");
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("진행 상태가 아닌 웨이팅 미루기는 불가능 합니다.");
     }
 
     @Test
@@ -182,22 +148,13 @@ class WaitingTest {
         var minimumWaitingPeople = 2;
         var maximumWaitingPeople = 5;
 
-        var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, maximumWaitingPeople, minimumWaitingPeople);
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
 
-        var waitingPeople = new WaitingPeople(2, 0);
+        var waitingPeople = DataInitializerFactory.waitingPeople(2, 0);
 
-        var waiting = Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .userId(userId)
-            .waitingPeople(waitingPeople)
-            .build();
+        var waiting = DataInitializerFactory.waiting(userId, shopWaiting, waitingPeople);
 
         //when
         waiting.addPostponedCount();
@@ -205,8 +162,8 @@ class WaitingTest {
 
         //then
         Assertions.assertThatThrownBy(waiting::addPostponedCount)
-            .isInstanceOf(IllegalStateException.class)
-            .hasMessage("웨이팅 미루기는 2회 초과하여 불가능 합니다.");
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("웨이팅 미루기는 2회 초과하여 불가능 합니다.");
     }
 
     @ParameterizedTest
@@ -214,28 +171,20 @@ class WaitingTest {
     @DisplayName("Waiting의 상태가 PROGRESS라면 다른 상태로 변경이 가능하다.")
     public void changeWaitingStatusTest(WaitingStatus waitingStatus) {
         //given
+        //given
         var shopId = 1L;
         var userId = 1L;
         var maximumWaiting = 10;
         var minimumWaitingPeople = 2;
         var maximumWaitingPeople = 5;
 
-        var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, maximumWaitingPeople, minimumWaitingPeople);
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
 
-        var waitingPeople = new WaitingPeople(2, 0);
+        var waitingPeople = DataInitializerFactory.waitingPeople(2, 0);
 
-        var waiting = Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .userId(userId)
-            .waitingPeople(waitingPeople)
-            .build();
+        var waiting = DataInitializerFactory.waiting(userId, shopWaiting, waitingPeople);
 
         //when
         waiting.changeWaitingStatus(waitingStatus);
@@ -255,30 +204,21 @@ class WaitingTest {
         var minimumWaitingPeople = 2;
         var maximumWaitingPeople = 5;
 
-        var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, maximumWaitingPeople, minimumWaitingPeople);
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
 
-        var waitingPeople = new WaitingPeople(2, 0);
+        var waitingPeople = DataInitializerFactory.waitingPeople(2, 0);
 
-        var waiting = Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .userId(userId)
-            .waitingPeople(waitingPeople)
-            .build();
+        var waiting = DataInitializerFactory.waiting(userId, shopWaiting, waitingPeople);
 
         //when
         waiting.changeWaitingStatus(waitingStatus);
 
         //then
         assertThatThrownBy(() -> waiting.changeWaitingStatus(WaitingStatus.PROGRESS))
-            .isInstanceOf(IllegalStateException.class)
-            .hasMessage("진행 상태가 아니면 상태 변경이 불가능 합니다.");
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("진행 상태가 아니면 상태 변경이 불가능 합니다.");
     }
 
     @ParameterizedTest
@@ -291,29 +231,24 @@ class WaitingTest {
         var minimumWaitingPeople = 2;
         var maximumWaitingPeople = 5;
 
-        var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, maximumWaitingPeople, minimumWaitingPeople);
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
 
         //when&then
         assertThatThrownBy(() -> Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .waitingPeople(waitingPeople)
-            .userId(1L)
-            .build())
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage(exceptionMessage);
+                .shopWaiting(shopWaiting)
+                .waitingPeople(waitingPeople)
+                .userId(1L)
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(exceptionMessage);
     }
 
     static Stream<Arguments> waitingPeopleAndExceptionMessage() {
         return Stream.of(
-            Arguments.arguments(new WaitingPeople(1, 0), "웨이팅 인원은 2명 이상이어야 합니다."),
-            Arguments.arguments(new WaitingPeople(6, 0), "웨이팅 인원은 5명 이하여야 합니다.")
+                Arguments.arguments(DataInitializerFactory.waitingPeople(1, 0), "웨이팅 인원은 2명 이상이어야 합니다."),
+                Arguments.arguments(DataInitializerFactory.waitingPeople(6, 0), "웨이팅 인원은 5명 이하여야 합니다.")
         );
     }
 
@@ -327,25 +262,25 @@ class WaitingTest {
         var maximumWaitingPeople = 5;
 
         var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+                .shopId(shopId)
+                .maximumWaiting(maximumWaiting)
+                .minimumWaitingPeople(minimumWaitingPeople)
+                .maximumWaitingPeople(maximumWaitingPeople)
+                .build();
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
 
         //when & then
         assertThatThrownBy(() -> Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .waitingPeople(new WaitingPeople(2, 2))
-            .build())
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("유아 손님 입장이 불가능한 매장입니다.");
+                .shopWaiting(shopWaiting)
+                .waitingPeople(new WaitingPeople(2, 2))
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("유아 손님 입장이 불가능한 매장입니다.");
     }
 
     @Test
-    @DisplayName("아동 손님을 받지 매장에 아동 손님을 추가할 수 있다.")
+    @DisplayName("아동 손님을 받는 매장에 아동 손님을 추가할 수 있다.")
     void shouldNotThrowExceptionWhenAddingChildGuestToChildEnabledStore() {
         //given
         var shopId = 1L;
@@ -353,21 +288,13 @@ class WaitingTest {
         var minimumWaitingPeople = 2;
         var maximumWaitingPeople = 5;
 
-        var shopWaiting = ShopWaiting.builder()
-            .shopId(shopId)
-            .maximumWaiting(maximumWaiting)
-            .minimumWaitingPeople(minimumWaitingPeople)
-            .maximumWaitingPeople(maximumWaitingPeople)
-            .build();
+        var shopWaiting = DataInitializerFactory.shopWaiting(shopId, maximumWaiting, maximumWaitingPeople, minimumWaitingPeople);
 
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
         shopWaiting.updateChildEnabled(true);
 
         //when
-        var waiting = Waiting.builder()
-            .shopWaiting(shopWaiting)
-            .waitingPeople(new WaitingPeople(2, 2))
-            .build();
+        var waiting = DataInitializerFactory.waiting(1L, shopWaiting, DataInitializerFactory.waitingPeople(2, 2));
 
         //then
         assertThat(waiting).isNotNull();


### PR DESCRIPTION
## 🖊️ 1. Changes

- 

## 🖼️ 2. Screenshot

-

## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer
- 점주가 갖고 있는 매장 중에서 웨이팅 상태가 waitingStatus인 웨이팅 정보를 조회합니다.
```
@Query("""
            SELECT new com.mdh.devtable.ownerwaiting.presentaion.dto.WaitingInfoResponseForOwner(w.waitingNumber, u.email)
            FROM Waiting w
            JOIN User u ON w.userId = u.id
            JOIN Shop s ON w.shopWaiting.shopId = s.id
            WHERE s.userId = :ownerId AND
                  w.waitingStatus = :waitingStatus
            """)
    List<WaitingInfoResponseForOwner> findWaitingByOwnerIdAndWaitingStatus(@Param("ownerId") Long ownerId, @Param("waitingStatus") WaitingStatus waitingStatus);
```
- WaitingRepository에 쿼리를 작성해서 다른 WaitingRepository를 작성하는 분과 충돌이 날 것입니다.
- WaitingRepository 테스트를 만들어 테스트를 진행할지, OwnerWaitingRepository를 만들어 테스트를 진행할지 고민했는데 아무래도 점주가 사용하는 쿼리이기 때문에 테스트 클래스를 OwnerWaitingRepository테스트를 만들어서 진행했습니다.
- 그리고 응답 dto의 필드가 phoneNumber인데 email을 집어 넣었습니다. 이거 추후 필드 명 변경할 때 email 대신 phoneNumber 넣을 수 있도록 할게요
## ✅ 5. Plans
- [ ] - api 엔드포인트도 만들어서 올릴게요
- [ ] - 
