### PR TITLE
[MDH-59] feat : 점주가 갖고 있는 매장의 웨이팅 조회 서비스, 테스트 코드 작성

### DIFF
--- a/src/main/java/com/mdh/devtable/global/util/RegularExpression.java
+++ b/src/main/java/com/mdh/devtable/global/util/RegularExpression.java
@@ -5,4 +5,6 @@ public class RegularExpression {
     public static final String EMAIL = "[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?";
 
     public static final String PASSWORD = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=\\S+$).{8,}$";
+
+    public static final String PHONE_NUMBER = "^[0-9]{10,11}$";
 }

--- a/src/main/java/com/mdh/devtable/ownerwaiting/application/OwnerWaitingService.java
+++ b/src/main/java/com/mdh/devtable/ownerwaiting/application/OwnerWaitingService.java
@@ -3,10 +3,13 @@ package com.mdh.devtable.ownerwaiting.application;
 import com.mdh.devtable.ownerwaiting.infra.persistence.OwnerWaitingRepository;
 import com.mdh.devtable.ownerwaiting.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
 import com.mdh.devtable.ownerwaiting.presentaion.dto.OwnerWaitingStatusChangeRequest;
+import com.mdh.devtable.ownerwaiting.presentaion.dto.WaitingInfoRequestForOwner;
+import com.mdh.devtable.ownerwaiting.presentaion.dto.WaitingInfoResponseForOwner;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 
 @Service
@@ -27,5 +30,10 @@ public class OwnerWaitingService {
         var waiting = ownerWaitingRepository.findWaitingByWaitingId(waitingId)
                 .orElseThrow(() -> new NoSuchElementException("웨이팅 조회 결과가 없습니다."));
         waiting.changeWaitingStatus(request.waitingStatus());
+    }
+
+    @Transactional(readOnly = true)
+    public List<WaitingInfoResponseForOwner> findWaitingByShopIdAndWaitingStatus(Long ownerId, WaitingInfoRequestForOwner request) {
+        return ownerWaitingRepository.findWaitingByOwnerIdAndWaitingStatus(ownerId, request.waitingStatus());
     }
 }

--- a/src/main/java/com/mdh/devtable/ownerwaiting/infra/persistence/OwnerWaitingRepository.java
+++ b/src/main/java/com/mdh/devtable/ownerwaiting/infra/persistence/OwnerWaitingRepository.java
@@ -1,9 +1,12 @@
 package com.mdh.devtable.ownerwaiting.infra.persistence;
 
 
+import com.mdh.devtable.ownerwaiting.presentaion.dto.WaitingInfoResponseForOwner;
 import com.mdh.devtable.waiting.domain.ShopWaiting;
 import com.mdh.devtable.waiting.domain.Waiting;
+import com.mdh.devtable.waiting.domain.WaitingStatus;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface OwnerWaitingRepository {
@@ -11,5 +14,7 @@ public interface OwnerWaitingRepository {
     Optional<ShopWaiting> findShopWaitingByShopId(Long shopId);
 
     Optional<Waiting> findWaitingByWaitingId(Long waitingId);
+
+    List<WaitingInfoResponseForOwner> findWaitingByOwnerIdAndWaitingStatus(Long ownerId, WaitingStatus waitingStatus);
 
 }

--- a/src/main/java/com/mdh/devtable/ownerwaiting/infra/persistence/OwnerWaitingRepositoryImpl.java
+++ b/src/main/java/com/mdh/devtable/ownerwaiting/infra/persistence/OwnerWaitingRepositoryImpl.java
@@ -1,12 +1,15 @@
 package com.mdh.devtable.ownerwaiting.infra.persistence;
 
+import com.mdh.devtable.ownerwaiting.presentaion.dto.WaitingInfoResponseForOwner;
 import com.mdh.devtable.waiting.domain.ShopWaiting;
 import com.mdh.devtable.waiting.domain.Waiting;
+import com.mdh.devtable.waiting.domain.WaitingStatus;
 import com.mdh.devtable.waiting.infra.persistence.ShopWaitingRepository;
 import com.mdh.devtable.waiting.infra.persistence.WaitingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -24,5 +27,10 @@ public class OwnerWaitingRepositoryImpl implements OwnerWaitingRepository {
     @Override
     public Optional<Waiting> findWaitingByWaitingId(Long waitingId) {
         return waitingRepository.findById(waitingId);
+    }
+
+    @Override
+    public List<WaitingInfoResponseForOwner> findWaitingByOwnerIdAndWaitingStatus(Long ownerId, WaitingStatus waitingStatus) {
+        return waitingRepository.findWaitingByOwnerIdAndWaitingStatus(ownerId, waitingStatus);
     }
 }

--- a/src/main/java/com/mdh/devtable/ownerwaiting/presentaion/dto/WaitingInfoRequestForOwner.java
+++ b/src/main/java/com/mdh/devtable/ownerwaiting/presentaion/dto/WaitingInfoRequestForOwner.java
@@ -1,0 +1,8 @@
+package com.mdh.devtable.ownerwaiting.presentaion.dto;
+
+import com.mdh.devtable.waiting.domain.WaitingStatus;
+
+public record WaitingInfoRequestForOwner(
+        WaitingStatus waitingStatus
+) {
+}

--- a/src/main/java/com/mdh/devtable/ownerwaiting/presentaion/dto/WaitingInfoResponseForOwner.java
+++ b/src/main/java/com/mdh/devtable/ownerwaiting/presentaion/dto/WaitingInfoResponseForOwner.java
@@ -1,0 +1,7 @@
+package com.mdh.devtable.ownerwaiting.presentaion.dto;
+
+public record WaitingInfoResponseForOwner(
+        int waitingNumber,
+        String phoneNumber
+) {
+}

--- a/src/main/java/com/mdh/devtable/user/domain/User.java
+++ b/src/main/java/com/mdh/devtable/user/domain/User.java
@@ -27,10 +27,14 @@ public class User extends BaseTimeEntity {
     @Column(name = "password", length = 20, nullable = false)
     private String password;
 
+    @Column(name = "phone_number", length = 15, nullable = false)
+    private String phoneNumber;
+
     @Builder
-    public User(String email, Role role, String password) {        
+    public User(String email, Role role, String password, String phoneNumber) {
         this.email = email;
         this.role = role;
         this.password = password;
+        this.phoneNumber = phoneNumber;
     }
 }

--- a/src/main/java/com/mdh/devtable/user/presentation/dto/SignUpRequest.java
+++ b/src/main/java/com/mdh/devtable/user/presentation/dto/SignUpRequest.java
@@ -19,12 +19,17 @@ public record SignUpRequest(
         String password,
 
         @NotEmpty(message = "비밀번호 확인을 입력해 주세요.")
-        String passwordCheck
+        String passwordCheck,
+
+        @Pattern(regexp = RegularExpression.PHONE_NUMBER, message = "핸드폰 번호는 10~11자리의 숫자만 입력해 주세요.")
+        String phoneNumber
 ) {
     public User toEntity() {
         return User.builder()
                 .email(email)
                 .password(password)
-                .role(Role.GUEST).build();
+                .role(Role.GUEST)
+                .phoneNumber(phoneNumber)
+                .build();
     }
 }

--- a/src/main/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepository.java
+++ b/src/main/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepository.java
@@ -1,14 +1,27 @@
 package com.mdh.devtable.waiting.infra.persistence;
 
+import com.mdh.devtable.ownerwaiting.presentaion.dto.WaitingInfoResponseForOwner;
 import com.mdh.devtable.waiting.domain.Waiting;
+import com.mdh.devtable.waiting.domain.WaitingStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface WaitingRepository extends JpaRepository<Waiting, Long> {
 
     @Query("select w from Waiting w where w.waitingStatus = 'PROGRESS' and w.userId = :userId")
     Optional<Waiting> findByProgressWaiting(@Param("userId") Long userId);
+
+    @Query("""
+            SELECT new com.mdh.devtable.ownerwaiting.presentaion.dto.WaitingInfoResponseForOwner(w.waitingNumber, u.email)
+            FROM Waiting w
+            JOIN User u ON w.userId = u.id
+            JOIN Shop s ON w.shopWaiting.shopId = s.id
+            WHERE s.userId = :ownerId AND
+                  w.waitingStatus = :waitingStatus
+            """)
+    List<WaitingInfoResponseForOwner> findWaitingByOwnerIdAndWaitingStatus(@Param("ownerId") Long ownerId, @Param("waitingStatus") WaitingStatus waitingStatus);
 }

--- a/src/test/java/com/mdh/devtable/DataInitializerFactory.java
+++ b/src/test/java/com/mdh/devtable/DataInitializerFactory.java
@@ -14,6 +14,7 @@ public final class DataInitializerFactory {
                 .email("owner@example.com")
                 .role(Role.OWNER)
                 .password("password123")
+                .phoneNumber("01056781234")
                 .build();
     }
 
@@ -22,6 +23,7 @@ public final class DataInitializerFactory {
                 .email("guest@example.com")
                 .role(Role.GUEST)
                 .password("password123")
+                .phoneNumber("01012345678")
                 .build();
     }
 

--- a/src/test/java/com/mdh/devtable/ownerwaiting/application/OwnerWaitingServiceTest.java
+++ b/src/test/java/com/mdh/devtable/ownerwaiting/application/OwnerWaitingServiceTest.java
@@ -4,6 +4,8 @@ import com.mdh.devtable.DataInitializerFactory;
 import com.mdh.devtable.ownerwaiting.infra.persistence.OwnerWaitingRepository;
 import com.mdh.devtable.ownerwaiting.presentaion.dto.OwnerShopWaitingStatusChangeRequest;
 import com.mdh.devtable.ownerwaiting.presentaion.dto.OwnerWaitingStatusChangeRequest;
+import com.mdh.devtable.ownerwaiting.presentaion.dto.WaitingInfoRequestForOwner;
+import com.mdh.devtable.ownerwaiting.presentaion.dto.WaitingInfoResponseForOwner;
 import com.mdh.devtable.waiting.domain.ShopWaitingStatus;
 import com.mdh.devtable.waiting.domain.WaitingStatus;
 import org.assertj.core.api.Assertions;
@@ -15,6 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static org.mockito.BDDMockito.given;
@@ -69,5 +72,21 @@ class OwnerWaitingServiceTest {
         // then
         verify(ownerWaitingRepository, times(1)).findWaitingByWaitingId(waitingId);
         Assertions.assertThat(WaitingStatus.valueOf(status)).isEqualTo(waiting.getWaitingStatus());
+    }
+
+    @DisplayName("점주 id, 웨이팅 상태로 웨이팅을 조회할 수 있다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"PROGRESS", "CANCEL", "NO_SHOW", "VISITED"})
+    void findWaitingByShopIdAndWaitingStatus(String status) {
+        var ownerId = 1L;
+        var response = Collections.singletonList(new WaitingInfoResponseForOwner(1, "test"));
+        var request = new WaitingInfoRequestForOwner(WaitingStatus.valueOf(status));
+        given(ownerWaitingRepository.findWaitingByOwnerIdAndWaitingStatus(ownerId, WaitingStatus.valueOf(status))).willReturn(response);
+
+        //when
+        var result = ownerWaitingService.findWaitingByShopIdAndWaitingStatus(ownerId, request);
+
+        //then
+        Assertions.assertThat(result).isEqualTo(response);
     }
 }

--- a/src/test/java/com/mdh/devtable/ownerwaiting/infra/persistence/OwnerWaitingRepositoryTest.java
+++ b/src/test/java/com/mdh/devtable/ownerwaiting/infra/persistence/OwnerWaitingRepositoryTest.java
@@ -1,0 +1,76 @@
+package com.mdh.devtable.ownerwaiting.infra.persistence;
+
+import com.mdh.devtable.DataInitializerFactory;
+import com.mdh.devtable.global.config.JpaConfig;
+import com.mdh.devtable.shop.infra.persistence.RegionRepository;
+import com.mdh.devtable.shop.infra.persistence.ShopRepository;
+import com.mdh.devtable.user.infra.persistence.UserRepository;
+import com.mdh.devtable.waiting.domain.ShopWaitingStatus;
+import com.mdh.devtable.waiting.domain.WaitingStatus;
+import com.mdh.devtable.waiting.infra.persistence.ShopWaitingRepository;
+import com.mdh.devtable.waiting.infra.persistence.WaitingRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import({JpaConfig.class})
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class OwnerWaitingRepositoryTest {
+
+    @Autowired
+    private WaitingRepository waitingRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ShopWaitingRepository shopWaitingRepository;
+
+    @Autowired
+    private ShopRepository shopRepository;
+
+    @Autowired
+    private RegionRepository regionRepository;
+
+    @DisplayName("점주 id, 웨이팅 상태로 웨이팅을 조회할 수 있다.")
+    @Test
+    void findWaitingByOwnerIdAndWaitingStatus() {
+        //given
+        var owner = DataInitializerFactory.owner();
+        userRepository.save(owner);
+
+        var region = DataInitializerFactory.region();
+        regionRepository.save(region);
+
+        var shopDetails = DataInitializerFactory.shopDetails();
+        var shopAddress = DataInitializerFactory.shopAddress();
+        var shop = DataInitializerFactory.shop(owner.getId(), shopDetails, region, shopAddress);
+        shopRepository.save(shop);
+
+        var shopWaiting = DataInitializerFactory.shopWaiting(shop.getId(), 30, 8, 2);
+        shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
+        shopWaiting.updateChildEnabled(true);
+        shopWaitingRepository.save(shopWaiting);
+
+        var waitingPeople = DataInitializerFactory.waitingPeople(2, 3);
+        var waiting = DataInitializerFactory.waiting(owner.getId(), shopWaiting, waitingPeople);
+        waiting.changeWaitingStatus(WaitingStatus.PROGRESS);
+        waitingRepository.save(waiting);
+
+        //when
+        var result = waitingRepository.findWaitingByOwnerIdAndWaitingStatus(owner.getId(), WaitingStatus.PROGRESS);
+
+        //then
+        assertThat(result).isNotEmpty();
+        assertThat(result.get(0).phoneNumber()).isEqualTo(owner.getEmail()); // email을 나중에 phoneNumber로 리팩토링 해야함
+        assertThat(result.get(0).waitingNumber()).isEqualTo(waiting.getWaitingNumber());
+    }
+}

--- a/src/test/java/com/mdh/devtable/user/application/UserServiceTest.java
+++ b/src/test/java/com/mdh/devtable/user/application/UserServiceTest.java
@@ -28,7 +28,7 @@ public class UserServiceTest {
     @DisplayName("회원가입을 한다.")
     public void testSignUp() {
         // given
-        var signUpRequest = new SignUpRequest("test@example.com", "password123", "password123");
+        var signUpRequest = new SignUpRequest("test@example.com", "password123", "password123", "01012345678");
         var expectedUser = signUpRequest.toEntity();
         given(userRepository.save(any(User.class))).willReturn(expectedUser);
 

--- a/src/test/java/com/mdh/devtable/user/presentation/UserControllerTest.java
+++ b/src/test/java/com/mdh/devtable/user/presentation/UserControllerTest.java
@@ -9,9 +9,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.restdocs.payload.PayloadDocumentation;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -36,7 +34,7 @@ class UserControllerTest extends RestDocsSupport {
     @DisplayName("회원가입을 한다.")
     void signUp() throws Exception {
         //given
-        var signUpRequest = new SignUpRequest("test@example.com", "password123", "password123");
+        var signUpRequest = new SignUpRequest("test@example.com", "password123", "password123", "01012345678");
         var expectedId = 1L;
         when(userService.signUp(signUpRequest)).thenReturn(expectedId);
 
@@ -53,7 +51,8 @@ class UserControllerTest extends RestDocsSupport {
                         requestFields(
                                 fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
                                 fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호"),
-                                fieldWithPath("passwordCheck").type(JsonFieldType.STRING).description("비밀번호 확인")
+                                fieldWithPath("passwordCheck").type(JsonFieldType.STRING).description("비밀번호 확인"),
+                                fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("핸드폰 번호")
                         ),
                         responseFields(fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("상태 코드"),
                                 fieldWithPath("data").type(JsonFieldType.STRING).description("생성된 URI + id"),
@@ -66,7 +65,7 @@ class UserControllerTest extends RestDocsSupport {
     @DisplayName("회원가입시 email을 잘못 입력한다.")
     void signUpException1() throws Exception {
         //given
-        var signUpRequest = new SignUpRequest("tesexample.com", "password123", "password123");
+        var signUpRequest = new SignUpRequest("tesexample.com", "password123", "password123", "01012345678");
 
         //when & then
         mockMvc.perform(post("/api/v1/users")
@@ -76,11 +75,12 @@ class UserControllerTest extends RestDocsSupport {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.statusCode").value("400"))
                 .andExpect(jsonPath("$.data.title").value("MethodArgumentNotValidException"))
-                .andDo(document("user-sign-up-invalid-password",
+                .andDo(document("user-sign-up-invalid-email",
                         requestFields(
                                 fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
                                 fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호"),
-                                fieldWithPath("passwordCheck").type(JsonFieldType.STRING).description("비밀번호 확인")
+                                fieldWithPath("passwordCheck").type(JsonFieldType.STRING).description("비밀번호 확인"),
+                                fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("핸드폰 번호")
                         ),
                         responseFields(
                                 fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("상태 코드"),
@@ -100,7 +100,7 @@ class UserControllerTest extends RestDocsSupport {
     @DisplayName("회원가입시 password를 잘못 입력한다.")
     void signUpException2() throws Exception {
         // given
-        var signUpRequest = new SignUpRequest("test@example.com", "invalid", "invalid");
+        var signUpRequest = new SignUpRequest("test@example.com", "invalid", "invalid", "01012345678");
 
         // when & then
         mockMvc.perform(post("/api/v1/users")
@@ -114,7 +114,8 @@ class UserControllerTest extends RestDocsSupport {
                         requestFields(
                                 fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
                                 fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호"),
-                                fieldWithPath("passwordCheck").type(JsonFieldType.STRING).description("비밀번호 확인")
+                                fieldWithPath("passwordCheck").type(JsonFieldType.STRING).description("비밀번호 확인"),
+                                fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("핸드폰 번호")
                         ),
                         responseFields(
                                 fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("상태 코드"),
@@ -134,7 +135,7 @@ class UserControllerTest extends RestDocsSupport {
     @DisplayName("회원가입시 password 확인을 잘못 입력한다.")
     void signUpException3() throws Exception {
         //given
-        var signUpRequest = new SignUpRequest("test@example.com", "password123", "password1234"); // 비밀번호와 비밀번호 확인이 다름
+        var signUpRequest = new SignUpRequest("test@example.com", "password123", "password1234", "01012345678"); // 비밀번호와 비밀번호 확인이 다름
 
         //when & then
         mockMvc.perform(post("/api/v1/users")
@@ -144,11 +145,12 @@ class UserControllerTest extends RestDocsSupport {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.statusCode").value("400"))
                 .andExpect(jsonPath("$.data.title").value("MethodArgumentNotValidException"))
-                .andDo(document("user-sign-up-invalid-password",
+                .andDo(document("user-sign-up-invalid-password-check",
                         requestFields(
                                 fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
                                 fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호"),
-                                fieldWithPath("passwordCheck").type(JsonFieldType.STRING).description("비밀번호 확인")
+                                fieldWithPath("passwordCheck").type(JsonFieldType.STRING).description("비밀번호 확인"),
+                                fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("핸드폰 번호")
                         ),
                         responseFields(
                                 fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("상태 코드"),
@@ -158,6 +160,42 @@ class UserControllerTest extends RestDocsSupport {
                                 fieldWithPath("data.detail").type(JsonFieldType.STRING).description("상세 설명"),
                                 fieldWithPath("data.instance").type(JsonFieldType.STRING).description("인스턴스 URI"),
                                 fieldWithPath("data.validationError").type(JsonFieldType.ARRAY).description("Validation 오류"),
+                                fieldWithPath("serverDateTime").type(JsonFieldType.STRING).description("서버 시간")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("회원가입시 핸드폰 번호를 잘못 입력한다.")
+    void signUpException4() throws Exception {
+        //given
+        var signUpRequest = new SignUpRequest("test@example.com", "password123", "password123", "010123456789101112");
+
+        //when & then
+        mockMvc.perform(post("/api/v1/users")
+                        .content(objectMapper.writeValueAsString(signUpRequest))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.statusCode").value("400"))
+                .andExpect(jsonPath("$.data.title").value("MethodArgumentNotValidException"))
+                .andDo(document("user-sign-up-invalid-phone-number",
+                        requestFields(
+                                fieldWithPath("email").type(JsonFieldType.STRING).description("이메일"),
+                                fieldWithPath("password").type(JsonFieldType.STRING).description("비밀번호"),
+                                fieldWithPath("passwordCheck").type(JsonFieldType.STRING).description("비밀번호 확인"),
+                                fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("핸드폰 번호")
+                        ),
+                        responseFields(
+                                fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("상태 코드"),
+                                fieldWithPath("data.type").type(JsonFieldType.STRING).description("타입"),
+                                fieldWithPath("data.title").type(JsonFieldType.STRING).description("타이틀"),
+                                fieldWithPath("data.status").type(JsonFieldType.NUMBER).description("상태 코드"),
+                                fieldWithPath("data.detail").type(JsonFieldType.STRING).description("상세 설명"),
+                                fieldWithPath("data.instance").type(JsonFieldType.STRING).description("인스턴스 URI"),
+                                fieldWithPath("data.validationError").type(JsonFieldType.ARRAY).description("Validation 오류"),
+                                fieldWithPath("data.validationError[].field").type(JsonFieldType.STRING).description("오류 필드"),
+                                fieldWithPath("data.validationError[].message").type(JsonFieldType.STRING).description("오류 메시지"),
                                 fieldWithPath("serverDateTime").type(JsonFieldType.STRING).description("서버 시간")
                         )
                 ));


### PR DESCRIPTION
## 🖊️ 1. Changes

- 

## 🖼️ 2. Screenshot

-

## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer
- 점주가 갖고 있는 매장 중에서 웨이팅 상태가 waitingStatus인 웨이팅 정보를 조회합니다.
```
@Query("""
            SELECT new com.mdh.devtable.ownerwaiting.presentaion.dto.WaitingInfoResponseForOwner(w.waitingNumber, u.email)
            FROM Waiting w
            JOIN User u ON w.userId = u.id
            JOIN Shop s ON w.shopWaiting.shopId = s.id
            WHERE s.userId = :ownerId AND
                  w.waitingStatus = :waitingStatus
            """)
    List<WaitingInfoResponseForOwner> findWaitingByOwnerIdAndWaitingStatus(@Param("ownerId") Long ownerId, @Param("waitingStatus") WaitingStatus waitingStatus);
```
- WaitingRepository에 쿼리를 작성해서 다른 WaitingRepository를 작성하는 분과 충돌이 날 것입니다.
- WaitingRepository 테스트를 만들어 테스트를 진행할지, OwnerWaitingRepository를 만들어 테스트를 진행할지 고민했는데 아무래도 점주가 사용하는 쿼리이기 때문에 테스트 클래스를 OwnerWaitingRepository테스트를 만들어서 진행했습니다.
- 그리고 응답 dto의 필드가 phoneNumber인데 email을 집어 넣었습니다. 이거 추후 필드 명 변경할 때 email 대신 phoneNumber 넣을 수 있도록 할게요
## ✅ 5. Plans
- [ ] - api 엔드포인트도 만들어서 올릴게요
- [ ] - 
