### PR TITLE
[MDH-16] 웨이팅 상세 조회

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -46,3 +46,7 @@ operation::waiting-cancel[snippets = 'http-request,http-response,request-body,re
 == 유저 개인의 웨이팅 조회
 
 operation::find-my-waitings[snippets = 'http-request,http-response,request-body,response-fields']
+
+== Waiting 상세 조회
+
+operation::waiting-de[snippets = 'http-request,http-response,request-body,response-fields']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -49,4 +49,4 @@ operation::find-my-waitings[snippets = 'http-request,http-response,request-body,
 
 == Waiting 상세 조회
 
-operation::waiting-de[snippets = 'http-request,http-response,request-body,response-fields']
+operation::waiting-detail-find[snippets = 'http-request,http-response,request-body,response-fields']

--- a/src/main/java/com/mdh/devtable/waiting/application/WaitingService.java
+++ b/src/main/java/com/mdh/devtable/waiting/application/WaitingService.java
@@ -1,6 +1,7 @@
 package com.mdh.devtable.waiting.application;
 
 import com.mdh.devtable.waiting.application.dto.UserWaitingResponse;
+import com.mdh.devtable.waiting.application.dto.WaitingDetailsResponse;
 import com.mdh.devtable.waiting.domain.Waiting;
 import com.mdh.devtable.waiting.domain.WaitingPeople;
 import com.mdh.devtable.waiting.domain.WaitingStatus;
@@ -26,18 +27,31 @@ public class WaitingService {
     private final WaitingServiceValidator waitingServiceValidator;
     private final WaitingLine waitingLine;
 
+    @Transactional(readOnly = true)
+    public WaitingDetailsResponse findWaitingDetails(Long waitingId) {
+        var waitingDetails = waitingRepository.findByWaitingDetails(waitingId)
+                .orElseThrow(() -> new NoSuchElementException("해당되는 웨이팅이 없습니다. waitingId = " + waitingId));
+        var shopId = waitingDetails.shopId();
+        var createdDate = waitingDetails.createdDate();
+
+        if (waitingDetails.waitingStatus() == WaitingStatus.PROGRESS) {
+            var rank = waitingLine.findRank(shopId, waitingId, createdDate);
+            return waitingDetails.toWaitingDetailsResponse(rank);
+        }
+
+        return waitingDetails.toWaitingDetailsResponse();
+    }
+
     @Transactional
     public Long createWaiting(WaitingCreateRequest waitingCreateRequest) {
         var shopId = waitingCreateRequest.shopId();
         var shopWaiting = shopWaitingRepository.findById(shopId)
                 .orElseThrow(() -> new IllegalStateException("해당 매장에 웨이팅 정보가 존재하지 않습니다. shopId : " + shopId));
 
-
         var userId = waitingCreateRequest.userId();
 
         if (waitingServiceValidator.isExistsWaiting(userId)) {
             throw new IllegalStateException("해당 매장에 이미 웨이팅이 등록되어있다면 웨이팅을 추가로 등록 할 수 없다. userId : " + userId);
-
         }
         shopWaiting.addWaitingCount();
 

--- a/src/main/java/com/mdh/devtable/waiting/application/WaitingService.java
+++ b/src/main/java/com/mdh/devtable/waiting/application/WaitingService.java
@@ -34,7 +34,7 @@ public class WaitingService {
         var shopId = waitingDetails.shopId();
         var createdDate = waitingDetails.createdDate();
 
-        if (waitingDetails.waitingStatus() == WaitingStatus.PROGRESS) {
+        if (waitingDetails.waitingStatus().isProgress()) {
             var rank = waitingLine.findRank(shopId, waitingId, createdDate);
             return waitingDetails.toWaitingDetailsResponse(rank);
         }

--- a/src/main/java/com/mdh/devtable/waiting/application/dto/ShopWaitingResponse.java
+++ b/src/main/java/com/mdh/devtable/waiting/application/dto/ShopWaitingResponse.java
@@ -1,0 +1,12 @@
+package com.mdh.devtable.waiting.application.dto;
+
+import com.mdh.devtable.shop.ShopDetails;
+import com.mdh.devtable.shop.ShopType;
+
+public record ShopWaitingResponse(
+        String shopName,
+        ShopType shopType,
+        String region,
+        ShopDetails shopDetails
+) {
+}

--- a/src/main/java/com/mdh/devtable/waiting/application/dto/WaitingDetailsResponse.java
+++ b/src/main/java/com/mdh/devtable/waiting/application/dto/WaitingDetailsResponse.java
@@ -1,0 +1,20 @@
+package com.mdh.devtable.waiting.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.mdh.devtable.waiting.domain.WaitingPeople;
+import com.mdh.devtable.waiting.domain.WaitingStatus;
+
+import java.time.LocalDateTime;
+
+public record WaitingDetailsResponse(
+        ShopWaitingResponse shop,
+        int waitingNumber,
+        Integer waitingRank,
+        WaitingStatus waitingStatus,
+        WaitingPeople waitingPeople,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+        LocalDateTime createdDate,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+        LocalDateTime modifiedDate
+) {
+}

--- a/src/main/java/com/mdh/devtable/waiting/domain/WaitingStatus.java
+++ b/src/main/java/com/mdh/devtable/waiting/domain/WaitingStatus.java
@@ -2,5 +2,12 @@ package com.mdh.devtable.waiting.domain;
 
 public enum WaitingStatus {
 
-    PROGRESS, CANCEL, NO_SHOW, VISITED
+    PROGRESS,
+    CANCEL,
+    NO_SHOW,
+    VISITED;
+
+    public boolean isProgress() {
+        return this == WaitingStatus.PROGRESS;
+    }
 }

--- a/src/main/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepository.java
+++ b/src/main/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepository.java
@@ -3,6 +3,7 @@ package com.mdh.devtable.waiting.infra.persistence;
 import com.mdh.devtable.waiting.domain.Waiting;
 import com.mdh.devtable.waiting.domain.WaitingStatus;
 import com.mdh.devtable.waiting.infra.persistence.dto.UserWaitingQueryDto;
+import com.mdh.devtable.waiting.infra.persistence.dto.WaitingDetails;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -22,4 +23,19 @@ public interface WaitingRepository extends JpaRepository<Waiting, Long> {
              where w.userId = :userId and w.waitingStatus = :waitingStatus
             """)
     List<UserWaitingQueryDto> findAllByUserIdAndWaitingStatus(@Param("userId") Long userId, @Param("waitingStatus") WaitingStatus waitingStatus);
+
+
+    @Query("""
+            select
+                new com.mdh.devtable.waiting.infra.persistence.dto.WaitingDetails
+                (
+                    s.name, s.shopType, s.region.district, s.shopDetails.phoneNumber, 
+                    w.waitingNumber, w.waitingStatus, w.waitingPeople.adultCount, w.waitingPeople.childCount, 
+                    w.createdDate, w.modifiedDate
+                )
+            from Waiting w
+            join Shop s on w.shopWaiting.shopId = s.id
+            where w.id = :waitingId
+            """)
+    WaitingDetails findByWaitingDetails(@Param("waitingId") Long waitingId);
 }

--- a/src/main/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepository.java
+++ b/src/main/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepository.java
@@ -29,13 +29,13 @@ public interface WaitingRepository extends JpaRepository<Waiting, Long> {
             select
                 new com.mdh.devtable.waiting.infra.persistence.dto.WaitingDetails
                 (
-                    s.name, s.shopType, s.region.district, s.shopDetails.phoneNumber, 
-                    w.waitingNumber, w.waitingStatus, w.waitingPeople.adultCount, w.waitingPeople.childCount, 
+                    s.name, s.shopType, s.region.district, s.shopDetails, 
+                    w.waitingNumber, w.waitingStatus, w.waitingPeople,
                     w.createdDate, w.modifiedDate
                 )
             from Waiting w
             join Shop s on w.shopWaiting.shopId = s.id
             where w.id = :waitingId
             """)
-    WaitingDetails findByWaitingDetails(@Param("waitingId") Long waitingId);
+    Optional<WaitingDetails> findByWaitingDetails(@Param("waitingId") Long waitingId);
 }

--- a/src/main/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepository.java
+++ b/src/main/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepository.java
@@ -29,7 +29,7 @@ public interface WaitingRepository extends JpaRepository<Waiting, Long> {
             select
                 new com.mdh.devtable.waiting.infra.persistence.dto.WaitingDetails
                 (
-                    s.name, s.shopType, s.region.district, s.shopDetails, 
+                    s.id, s.name, s.shopType, s.region.district, s.shopDetails, 
                     w.waitingNumber, w.waitingStatus, w.waitingPeople,
                     w.createdDate, w.modifiedDate
                 )

--- a/src/main/java/com/mdh/devtable/waiting/infra/persistence/dto/WaitingDetails.java
+++ b/src/main/java/com/mdh/devtable/waiting/infra/persistence/dto/WaitingDetails.java
@@ -1,26 +1,38 @@
 package com.mdh.devtable.waiting.infra.persistence.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
+import com.mdh.devtable.shop.ShopDetails;
 import com.mdh.devtable.shop.ShopType;
+import com.mdh.devtable.waiting.application.dto.ShopWaitingResponse;
+import com.mdh.devtable.waiting.application.dto.WaitingDetailsResponse;
+import com.mdh.devtable.waiting.domain.WaitingPeople;
 import com.mdh.devtable.waiting.domain.WaitingStatus;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
 import java.time.LocalDateTime;
 
-@Getter
-@AllArgsConstructor
-public class WaitingDetails {
-    String shopName;
-    ShopType shopType;
-    String region;
-    String phoneNumber;
-    int waitingNumber;
-    WaitingStatus waitingStatus;
-    int adultCount;
-    int childCount;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
-    LocalDateTime createdAt;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
-    LocalDateTime updatedAt;
+public record WaitingDetails(
+        Long shopId,
+        String shopName,
+        ShopType shopType,
+        String region,
+        ShopDetails shopDetails,
+        int waitingNumber,
+        WaitingStatus waitingStatus,
+        WaitingPeople waitingPeople,
+        LocalDateTime createdDate,
+        LocalDateTime modifiedDate
+) {
+    public WaitingDetailsResponse toWaitingDetailsResponse(Integer waitingRank) {
+        var shopWaitingInfo = new ShopWaitingResponse(shopName, shopType, region, shopDetails);
+        return new WaitingDetailsResponse(shopWaitingInfo,
+                waitingNumber,
+                waitingRank,
+                waitingStatus,
+                waitingPeople,
+                createdDate,
+                modifiedDate);
+    }
+
+    public WaitingDetailsResponse toWaitingDetailsResponse() {
+        return toWaitingDetailsResponse(null);
+    }
 }

--- a/src/main/java/com/mdh/devtable/waiting/infra/persistence/dto/WaitingDetails.java
+++ b/src/main/java/com/mdh/devtable/waiting/infra/persistence/dto/WaitingDetails.java
@@ -1,0 +1,26 @@
+package com.mdh.devtable.waiting.infra.persistence.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.mdh.devtable.shop.ShopType;
+import com.mdh.devtable.waiting.domain.WaitingStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class WaitingDetails {
+    String shopName;
+    ShopType shopType;
+    String region;
+    String phoneNumber;
+    int waitingNumber;
+    WaitingStatus waitingStatus;
+    int adultCount;
+    int childCount;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    LocalDateTime createdAt;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    LocalDateTime updatedAt;
+}

--- a/src/main/java/com/mdh/devtable/waiting/presentation/UserWaitingController.java
+++ b/src/main/java/com/mdh/devtable/waiting/presentation/UserWaitingController.java
@@ -3,6 +3,7 @@ package com.mdh.devtable.waiting.presentation;
 import com.mdh.devtable.global.ApiResponse;
 import com.mdh.devtable.waiting.application.WaitingService;
 import com.mdh.devtable.waiting.application.dto.UserWaitingResponse;
+import com.mdh.devtable.waiting.application.dto.WaitingDetailsResponse;
 import com.mdh.devtable.waiting.presentation.dto.MyWaitingsRequest;
 import com.mdh.devtable.waiting.presentation.dto.WaitingCreateRequest;
 import jakarta.validation.Valid;
@@ -38,5 +39,11 @@ public class UserWaitingController {
     public ResponseEntity<ApiResponse<Void>> cancelWaiting(@PathVariable Long waitingId) {
         waitingService.cancelWaiting(waitingId);
         return new ResponseEntity<>(ApiResponse.noContent(null), HttpStatus.NO_CONTENT);
+    }
+
+    @GetMapping("/{waitingId}")
+    public ResponseEntity<ApiResponse<WaitingDetailsResponse>> findWaitingDetails(@PathVariable Long waitingId) {
+        var waitingDetailsResponse = waitingService.findWaitingDetails(waitingId);
+        return new ResponseEntity<>(ApiResponse.ok(waitingDetailsResponse), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/mdh/devtable/waiting/presentation/UserWaitingController.java
+++ b/src/main/java/com/mdh/devtable/waiting/presentation/UserWaitingController.java
@@ -22,7 +22,7 @@ public class UserWaitingController {
 
     private final WaitingService waitingService;
 
-    @GetMapping("/{userId}")
+    @GetMapping("/me/{userId}")
     public ResponseEntity<ApiResponse<List<UserWaitingResponse>>> findWaitingsByUserIdAndStatus(@RequestBody @Valid MyWaitingsRequest request) {
         var findUserWaitings = waitingService.findAllByUserIdAndStatus(request);
         return ResponseEntity.ok(ApiResponse.ok(findUserWaitings));

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -1,0 +1,1363 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.18">
+<title>Dev Table REST API 문서</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
+/* Uncomment the following line when using as a custom stylesheet */
+/* @import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700"; */
+html{font-family:sans-serif;-webkit-text-size-adjust:100%}
+a{background:none}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+b,strong{font-weight:bold}
+abbr{font-size:.9em}
+abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
+dfn{font-style:italic}
+hr{height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+audio,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type=checkbox],input[type=radio]{padding:0}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,::before,::after{box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:0}
+p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ul.square{list-style-type:square}
+ul.circle ul:not([class]),ul.disc ul:not([class]),ul.square ul:not([class]){list-style:inherit}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
+table thead,table tfoot{background:#f7f8f7}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt{background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+:not(pre).nobreak{word-wrap:normal}
+:not(pre).nowrap{white-space:nowrap}
+:not(pre).pre-wrap{white-space:pre-wrap}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
+pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
+pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
+pre>code{display:block}
+pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
+#content{margin-top:1.25em}
+#content::before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
+#content{margin-bottom:.625em}
+.sect1{padding-bottom:.625em}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+details{margin-left:1.25rem}
+details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
+details>summary::-webkit-details-marker{display:none}
+details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
+details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
+details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
+.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.prettyprint{background:#f7f7f8}
+pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
+pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
+pre.prettyprint li code[data-lang]::before{opacity:1}
+pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
+table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
+table.linenotable td.code{padding-left:.75em}
+table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
+pre.pygments span.linenos{display:inline-block;margin-right:.75em}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
+td.tableblock>.content>:last-child{margin-bottom:-1.25em}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>*>tr>*{border-width:1px}
+table.grid-cols>*>tr>*{border-width:0 1px}
+table.grid-rows>*>tr>*{border-width:1px 0}
+table.frame-all{border-width:1px}
+table.frame-ends{border-width:1px 0}
+table.frame-sides{border-width:0 1px}
+table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
+table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
+table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
+table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
+table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+li>p:empty:only-child::before{content:"";display:inline-block}
+ul.checklist>li>p:first-child{margin-left:-1em}
+ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
+ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+td.hdlist2{word-wrap:anywhere}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background:#00fafa}
+.black{color:#000}
+.black-background{background:#000}
+.blue{color:#0000bf}
+.blue-background{background:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background:#fa00fa}
+.gray{color:#606060}
+.gray-background{background:#7d7d7d}
+.green{color:#006000}
+.green-background{background:#007d00}
+.lime{color:#00bf00}
+.lime-background{background:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background:#7d0000}
+.navy{color:#000060}
+.navy-background{background:#00007d}
+.olive{color:#606000}
+.olive-background{background:#7d7d00}
+.purple{color:#600060}
+.purple-background{background:#7d007d}
+.red{color:#bf0000}
+.red-background{background:#fa0000}
+.silver{color:#909090}
+.silver-background{background:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]::after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt,summary{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]{border-bottom:1px dotted}
+abbr[title]::after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#header,#content,#footnotes,#footer{max-width:none}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span::before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+</style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/styles/github.min.css">
+</head>
+<body class="book toc2 toc-left">
+<div id="header">
+<h1>Dev Table REST API 문서</h1>
+<div class="details">
+<span id="revnumber">version 0.0.1-SNAPSHOT</span>
+</div>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#Dev-Table-API">Dev Table API</a></li>
+<li><a href="#Hello">Hello Get 요청</a>
+<ul class="sectlevel2">
+<li><a href="#Hello_http_request">HTTP request</a></li>
+<li><a href="#Hello_http_response">HTTP response</a></li>
+<li><a href="#Hello_request_body">Request body</a></li>
+<li><a href="#Hello_response_fields">Response fields</a></li>
+</ul>
+</li>
+<li><a href="#User">User 회원가입 요청</a>
+<ul class="sectlevel2">
+<li><a href="#User_http_request">HTTP request</a></li>
+<li><a href="#User_http_response">HTTP response</a></li>
+<li><a href="#User_request_body">Request body</a></li>
+<li><a href="#User_response_fields">Response fields</a></li>
+</ul>
+</li>
+<li><a href="#_user_패스워드_불일치">User 패스워드 불일치</a>
+<ul class="sectlevel2">
+<li><a href="#_user_패스워드_불일치_http_request">HTTP request</a></li>
+<li><a href="#_user_패스워드_불일치_http_response">HTTP response</a></li>
+<li><a href="#_user_패스워드_불일치_request_body">Request body</a></li>
+<li><a href="#_user_패스워드_불일치_response_fields">Response fields</a></li>
+</ul>
+</li>
+<li><a href="#Waiting">Waiting 생성</a>
+<ul class="sectlevel2">
+<li><a href="#Waiting_http_request">HTTP request</a></li>
+<li><a href="#Waiting_http_response">HTTP response</a></li>
+<li><a href="#Waiting_request_body">Request body</a></li>
+<li><a href="#Waiting_response_fields">Response fields</a></li>
+</ul>
+</li>
+<li><a href="#_waiting_생성_허용_범위_예외">Waiting 생성 허용 범위 예외</a>
+<ul class="sectlevel2">
+<li><a href="#_waiting_생성_허용_범위_예외_http_request">HTTP request</a></li>
+<li><a href="#_waiting_생성_허용_범위_예외_http_response">HTTP response</a></li>
+<li><a href="#_waiting_생성_허용_범위_예외_request_body">Request body</a></li>
+<li><a href="#_waiting_생성_허용_범위_예외_response_fields">Response fields</a></li>
+</ul>
+</li>
+<li><a href="#_waiting_입력_값_예외">Waiting 입력 값 예외</a>
+<ul class="sectlevel2">
+<li><a href="#_waiting_입력_값_예외_http_request">HTTP request</a></li>
+<li><a href="#_waiting_입력_값_예외_http_response">HTTP response</a></li>
+<li><a href="#_waiting_입력_값_예외_request_body">Request body</a></li>
+<li><a href="#_waiting_입력_값_예외_response_fields">Response fields</a></li>
+</ul>
+</li>
+<li><a href="#_waiting_취소">Waiting 취소</a>
+<ul class="sectlevel2">
+<li><a href="#_waiting_취소_http_request">HTTP request</a></li>
+<li><a href="#_waiting_취소_http_response">HTTP response</a></li>
+<li><a href="#_waiting_취소_request_body">Request body</a></li>
+<li><a href="#_waiting_취소_response_fields">Response fields</a></li>
+</ul>
+</li>
+<li><a href="#_waiting_상세_조회">Waiting 상세 조회</a>
+<ul class="sectlevel2">
+<li><a href="#_waiting_상세_조회_http_request">HTTP request</a></li>
+<li><a href="#_waiting_상세_조회_http_response">HTTP response</a></li>
+<li><a href="#_waiting_상세_조회_request_body">Request body</a></li>
+<li><a href="#_waiting_상세_조회_response_fields">Response fields</a></li>
+</ul>
+</li>
+</ul>
+</div>
+</div>
+<div id="content">
+<div class="sect1">
+<h2 id="Dev-Table-API"><a class="link" href="#Dev-Table-API">Dev Table API</a></h2>
+<div class="sectionbody">
+
+</div>
+</div>
+<div class="sect1">
+<h2 id="Hello"><a class="link" href="#Hello">Hello Get 요청</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="Hello_http_request"><a class="link" href="#Hello_http_request">HTTP request</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /hello HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Accept: application/json
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="Hello_http_response"><a class="link" href="#Hello_http_response">HTTP response</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 88
+
+{
+  "statusCode" : 200,
+  "data" : "hello",
+  "serverDateTime" : "2023-09-08T18:58:33"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="Hello_request_body"><a class="link" href="#Hello_request_body">Request body</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json"></code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="Hello_response_fields"><a class="link" href="#Hello_response_fields">Response fields</a></h3>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>statusCode</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상태코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">값</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>serverDateTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">서버시간</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="User"><a class="link" href="#User">User 회원가입 요청</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="User_http_request"><a class="link" href="#User_http_request">HTTP request</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/users HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 99
+Host: localhost:8080
+
+{
+  "email" : "test@example.com",
+  "password" : "password123",
+  "passwordCheck" : "password123"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="User_http_response"><a class="link" href="#User_http_response">HTTP response</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
+Content-Type: application/json;charset=UTF-8
+Content-Length: 98
+
+{
+  "statusCode" : 201,
+  "data" : "/api/v1/users/1",
+  "serverDateTime" : "2023-09-08T18:58:35"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="User_request_body"><a class="link" href="#User_request_body">Request body</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
+  "email" : "test@example.com",
+  "password" : "password123",
+  "passwordCheck" : "password123"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="User_response_fields"><a class="link" href="#User_response_fields">Response fields</a></h3>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>statusCode</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상태 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생성된 URI + id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>serverDateTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생성된 서버 시간</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_user_패스워드_불일치"><a class="link" href="#_user_패스워드_불일치">User 패스워드 불일치</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_user_패스워드_불일치_http_request"><a class="link" href="#_user_패스워드_불일치_http_request">HTTP request</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/users HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 99
+Host: localhost:8080
+
+{
+  "email" : "test@example.com",
+  "password" : "password123",
+  "passwordCheck" : "password123"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_user_패스워드_불일치_http_response"><a class="link" href="#_user_패스워드_불일치_http_response">HTTP response</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
+Content-Type: application/json;charset=UTF-8
+Content-Length: 98
+
+{
+  "statusCode" : 201,
+  "data" : "/api/v1/users/1",
+  "serverDateTime" : "2023-09-08T18:58:35"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_user_패스워드_불일치_request_body"><a class="link" href="#_user_패스워드_불일치_request_body">Request body</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
+  "email" : "test@example.com",
+  "password" : "password123",
+  "passwordCheck" : "password123"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_user_패스워드_불일치_response_fields"><a class="link" href="#_user_패스워드_불일치_response_fields">Response fields</a></h3>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>statusCode</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상태 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생성된 URI + id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>serverDateTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생성된 서버 시간</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="Waiting"><a class="link" href="#Waiting">Waiting 생성</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="Waiting_http_request"><a class="link" href="#Waiting_http_request">HTTP request</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/customer/v1/waitings HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 74
+Host: localhost:8080
+
+{
+  "userId" : 1,
+  "shopId" : 1,
+  "adultCount" : 4,
+  "childCount" : 2
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="Waiting_http_response"><a class="link" href="#Waiting_http_response">HTTP response</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
+Content-Type: application/json;charset=UTF-8
+Content-Length: 109
+
+{
+  "statusCode" : 201,
+  "data" : "/api/customer/v1/waitings1",
+  "serverDateTime" : "2023-09-08T18:58:35"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="Waiting_request_body"><a class="link" href="#Waiting_request_body">Request body</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
+  "userId" : 1,
+  "shopId" : 1,
+  "adultCount" : 4,
+  "childCount" : 2
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="Waiting_response_fields"><a class="link" href="#Waiting_response_fields">Response fields</a></h3>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>statusCode</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상태 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생성된 URI + id</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>serverDateTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생성된 서버 시간</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_waiting_생성_허용_범위_예외"><a class="link" href="#_waiting_생성_허용_범위_예외">Waiting 생성 허용 범위 예외</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_waiting_생성_허용_범위_예외_http_request"><a class="link" href="#_waiting_생성_허용_범위_예외_http_request">HTTP request</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/customer/v1/waitings HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 75
+Host: localhost:8080
+
+{
+  "userId" : 1,
+  "shopId" : 1,
+  "adultCount" : 0,
+  "childCount" : 31
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_waiting_생성_허용_범위_예외_http_response"><a class="link" href="#_waiting_생성_허용_범위_예외_http_response">HTTP response</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 400 Bad Request
+Content-Type: application/json;charset=UTF-8
+Content-Length: 1065
+
+{
+  "statusCode" : 400,
+  "data" : {
+    "type" : "about:blank",
+    "title" : "MethodArgumentNotValidException",
+    "status" : 400,
+    "detail" : "Validation failed for argument [0] in public org.springframework.http.ResponseEntity&lt;com.mdh.devtable.global.ApiResponse&lt;java.net.URI&gt;&gt; com.mdh.devtable.waiting.presentation.UserWaitingController.createWaiting(com.mdh.devtable.waiting.presentation.dto.WaitingCreateRequest): [Field error in object 'waitingCreateRequest' on field 'childCount': rejected value [31]; codes [Max.waitingCreateRequest.childCount,Max.childCount,Max.int,Max]; arguments [org.springframework.context.support.DefaultMessageSourceResolvable: codes [waitingCreateRequest.childCount,childCount]; arguments []; default message [childCount],30]; default message [유아 인원은 30 초과일 수 없습니다.]] ",
+    "instance" : "/api/customer/v1/waitings",
+    "validationError" : [ {
+      "field" : "childCount",
+      "message" : "유아 인원은 30 초과일 수 없습니다."
+    } ]
+  },
+  "serverDateTime" : "2023-09-08T18:58:35"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_waiting_생성_허용_범위_예외_request_body"><a class="link" href="#_waiting_생성_허용_범위_예외_request_body">Request body</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
+  "userId" : 1,
+  "shopId" : 1,
+  "adultCount" : 0,
+  "childCount" : 31
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_waiting_생성_허용_범위_예외_response_fields"><a class="link" href="#_waiting_생성_허용_범위_예외_response_fields">Response fields</a></h3>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>statusCode</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상태 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.type</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">타입</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">타이틀</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.status</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상태 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.detail</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상세 설명</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.instance</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">인스턴스 URI</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.validationError[].field</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유효성 검사 실패 필드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.validationError[].message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유효성 검사 실패 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>serverDateTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">서버 시간</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_waiting_입력_값_예외"><a class="link" href="#_waiting_입력_값_예외">Waiting 입력 값 예외</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_waiting_입력_값_예외_http_request"><a class="link" href="#_waiting_입력_값_예외_http_request">HTTP request</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/customer/v1/waitings HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 77
+Host: localhost:8080
+
+{
+  "userId" : 1,
+  "shopId" : null,
+  "adultCount" : 2,
+  "childCount" : 0
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_waiting_입력_값_예외_http_response"><a class="link" href="#_waiting_입력_값_예외_http_response">HTTP response</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 400 Bad Request
+Content-Type: application/json;charset=UTF-8
+Content-Length: 1059
+
+{
+  "statusCode" : 400,
+  "data" : {
+    "type" : "about:blank",
+    "title" : "MethodArgumentNotValidException",
+    "status" : 400,
+    "detail" : "Validation failed for argument [0] in public org.springframework.http.ResponseEntity&lt;com.mdh.devtable.global.ApiResponse&lt;java.net.URI&gt;&gt; com.mdh.devtable.waiting.presentation.UserWaitingController.createWaiting(com.mdh.devtable.waiting.presentation.dto.WaitingCreateRequest): [Field error in object 'waitingCreateRequest' on field 'shopId': rejected value [null]; codes [NotNull.waitingCreateRequest.shopId,NotNull.shopId,NotNull.java.lang.Long,NotNull]; arguments [org.springframework.context.support.DefaultMessageSourceResolvable: codes [waitingCreateRequest.shopId,shopId]; arguments []; default message [shopId]]; default message [매장 아이디는 null일 수 없습니다.]] ",
+    "instance" : "/api/customer/v1/waitings",
+    "validationError" : [ {
+      "field" : "shopId",
+      "message" : "매장 아이디는 null일 수 없습니다."
+    } ]
+  },
+  "serverDateTime" : "2023-09-08T18:58:35"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_waiting_입력_값_예외_request_body"><a class="link" href="#_waiting_입력_값_예외_request_body">Request body</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json">{
+  "userId" : 1,
+  "shopId" : null,
+  "adultCount" : 2,
+  "childCount" : 0
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_waiting_입력_값_예외_response_fields"><a class="link" href="#_waiting_입력_값_예외_response_fields">Response fields</a></h3>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>statusCode</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상태 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.type</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">타입</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">타이틀</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.status</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상태 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.detail</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상세 설명</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.instance</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">인스턴스 URI</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.validationError[].field</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유효성 검사 실패 필드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.validationError[].message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유효성 검사 실패 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>serverDateTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">서버 시간</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_waiting_취소"><a class="link" href="#_waiting_취소">Waiting 취소</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_waiting_취소_http_request"><a class="link" href="#_waiting_취소_http_request">HTTP request</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/customer/v1/waitings/1 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_waiting_취소_http_response"><a class="link" href="#_waiting_취소_http_response">HTTP response</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 204 No Content
+Content-Type: application/json;charset=UTF-8
+Content-Length: 85
+
+{
+  "statusCode" : 204,
+  "data" : null,
+  "serverDateTime" : "2023-09-08T18:58:35"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_waiting_취소_request_body"><a class="link" href="#_waiting_취소_request_body">Request body</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-json hljs" data-lang="json"></code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_waiting_취소_response_fields"><a class="link" href="#_waiting_취소_response_fields">Response fields</a></h3>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>statusCode</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상태 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 바디(비어있음)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>serverDateTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생성된 서버 시간</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_waiting_상세_조회"><a class="link" href="#_waiting_상세_조회">Waiting 상세 조회</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_waiting_상세_조회_http_request"><a class="link" href="#_waiting_상세_조회_http_request">HTTP request</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/customer/v1/waitings/1 HTTP/1.1
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_waiting_상세_조회_http_response"><a class="link" href="#_waiting_상세_조회_http_response">HTTP response</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 777
+
+{
+  "statusCode" : 200,
+  "data" : {
+    "shop" : {
+      "shopName" : "김밥천국",
+      "shopType" : "KOREAN",
+      "region" : "강남구",
+      "shopDetails" : {
+        "introduce" : "이 가게는 맛있는 음식을 제공합니다.",
+        "openingHours" : "월-토 : 10:00 AM - 9:00 PM",
+        "info" : "추가 정보 없음",
+        "url" : "https://www.example.com",
+        "phoneNumber" : "123-456-7890",
+        "holiday" : "일요일 휴무"
+      }
+    },
+    "waitingNumber" : 85,
+    "waitingRank" : 5,
+    "waitingStatus" : "PROGRESS",
+    "waitingPeople" : {
+      "adultCount" : 2,
+      "childCount" : 0
+    },
+    "createdDate" : "2023-09-08T16:00:00",
+    "modifiedDate" : "2023-09-08T16:00:00"
+  },
+  "serverDateTime" : "2023-09-08T18:58:35"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_waiting_상세_조회_request_body"><a class="link" href="#_waiting_상세_조회_request_body">Request body</a></h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-none hljs"></code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_waiting_상세_조회_response_fields"><a class="link" href="#_waiting_상세_조회_response_fields">Response fields</a></h3>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>statusCode</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상태 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.shop.shopName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상점 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.shop.shopType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상점 타입</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.shop.region</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상점 지역</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.shop.shopDetails.url</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상점 URL</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.shop.shopDetails.phoneNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상점 전화번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.shop.shopDetails.introduce</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상점 소개</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.shop.shopDetails.openingHours</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상점 영업 시간</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.shop.shopDetails.holiday</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상점 휴무일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.shop.shopDetails.info</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상점 간단 소개</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.waitingNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대기 번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.waitingRank</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대기 순위</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.waitingStatus</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">대기 상태</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.waitingPeople.adultCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">어른 인원 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.waitingPeople.childCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유아 인원 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.createdDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생성일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.modifiedDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">수정일</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>serverDateTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">서버 시간</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Version 0.0.1-SNAPSHOT<br>
+Last updated 2023-09-08 17:52:26 +0900
+</div>
+</div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>
+<script>
+if (!hljs.initHighlighting.called) {
+  hljs.initHighlighting.called = true
+  ;[].slice.call(document.querySelectorAll('pre.highlight > code[data-lang]')).forEach(function (el) { hljs.highlightBlock(el) })
+}
+</script>
+</body>
+</html>

--- a/src/test/java/com/mdh/devtable/DataInitializerFactory.java
+++ b/src/test/java/com/mdh/devtable/DataInitializerFactory.java
@@ -6,6 +6,10 @@ import com.mdh.devtable.user.domain.User;
 import com.mdh.devtable.waiting.domain.ShopWaiting;
 import com.mdh.devtable.waiting.domain.Waiting;
 import com.mdh.devtable.waiting.domain.WaitingPeople;
+import com.mdh.devtable.waiting.domain.WaitingStatus;
+import com.mdh.devtable.waiting.infra.persistence.dto.WaitingDetails;
+
+import java.time.LocalDateTime;
 
 public final class DataInitializerFactory {
 
@@ -92,5 +96,20 @@ public final class DataInitializerFactory {
                 .shopWaiting(shopWaiting)
                 .waitingPeople(waitingPeople)
                 .build();
+    }
+
+    public static WaitingDetails waitingDetails(ShopDetails shopDetails,
+                                                WaitingStatus waitingStatus,
+                                                WaitingPeople waitingPeople) {
+        return new WaitingDetails(1L,
+                "가게 이름",
+                ShopType.KOREAN,
+                "강남구",
+                shopDetails,
+                85,
+                waitingStatus,
+                waitingPeople,
+                LocalDateTime.now(),
+                LocalDateTime.now());
     }
 }

--- a/src/test/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepositoryTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepositoryTest.java
@@ -8,6 +8,7 @@ import com.mdh.devtable.user.infra.persistence.UserRepository;
 import com.mdh.devtable.waiting.domain.ShopWaitingStatus;
 import com.mdh.devtable.waiting.domain.WaitingStatus;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -79,5 +80,43 @@ class WaitingRepositoryTest {
         assertThat(findUserWaitings).hasSize(1);
         assertThat(findUserWaitings).extracting("shopId", "waitingId")
                 .contains(tuple(shop.getId(), waiting.getId()));
+    }
+
+    @Test
+    @DisplayName("웨이팅 아이디로 웨이팅 상세 정보를 가져온다.")
+    void findWaitingDetails() {
+        //given
+        var guest = DataInitializerFactory.guest();
+        var savedUser = userRepository.save(guest);
+
+        var region = DataInitializerFactory.region();
+        regionRepository.save(region);
+
+        var shopDetails = DataInitializerFactory.shopDetails();
+        var shopAddress = DataInitializerFactory.shopAddress();
+        var shop = DataInitializerFactory.shop(guest.getId(), shopDetails, region, shopAddress);
+        var savedShop = shopRepository.save(shop);
+
+        var shopWaiting = DataInitializerFactory.shopWaiting(savedUser.getId(), 20, 7, 2);
+        shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
+        var savedShopWaiting = shopWaitingRepository.save(shopWaiting);
+
+        var waitingPeople = DataInitializerFactory.waitingPeople(2, 0);
+        var waiting = DataInitializerFactory.waiting(savedUser.getId(), shopWaiting, waitingPeople);
+        var savedWaiting = waitingRepository.save(waiting);
+
+        //when
+        var waitingDetails = waitingRepository.findByWaitingDetails(savedWaiting.getId()).orElse(null);
+
+        //then
+        assertThat(waitingDetails.shopName()).isEqualTo(shop.getName());
+        assertThat(waitingDetails.region()).isEqualTo(region.getDistrict());
+        assertThat(waitingDetails.shopType()).isEqualTo(shop.getShopType());
+        assertThat(waitingDetails.shopDetails()).isEqualTo(shopDetails);
+        assertThat(waitingDetails.waitingNumber()).isEqualTo(waiting.getWaitingNumber());
+        assertThat(waitingDetails.waitingStatus()).isEqualTo(waiting.getWaitingStatus());
+        assertThat(waitingDetails.waitingPeople()).isEqualTo(waitingPeople);
+        assertThat(waitingDetails.createdDate()).isEqualTo(waiting.getCreatedDate());
+        assertThat(waitingDetails.modifiedDate()).isEqualTo(waiting.getModifiedDate());
     }
 }

--- a/src/test/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepositoryTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepositoryTest.java
@@ -17,7 +17,10 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.time.temporal.ChronoUnit;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 
 @DataJpaTest
@@ -117,7 +120,7 @@ class WaitingRepositoryTest {
         assertThat(waitingDetails.waitingNumber()).isEqualTo(waiting.getWaitingNumber());
         assertThat(waitingDetails.waitingStatus()).isEqualTo(waiting.getWaitingStatus());
         assertThat(waitingDetails.waitingPeople()).usingRecursiveComparison().isEqualTo(waitingPeople);
-        assertThat(waitingDetails.createdDate()).isEqualTo(waiting.getCreatedDate());
-        assertThat(waitingDetails.modifiedDate()).isEqualTo(waiting.getModifiedDate());
+        assertThat(waitingDetails.createdDate()).isCloseTo(waiting.getCreatedDate(), within(1, ChronoUnit.SECONDS));
+        assertThat(waitingDetails.modifiedDate()).isCloseTo(waiting.getModifiedDate(), within(1, ChronoUnit.SECONDS));
     }
 }

--- a/src/test/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepositoryTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/infra/persistence/WaitingRepositoryTest.java
@@ -97,25 +97,26 @@ class WaitingRepositoryTest {
         var shop = DataInitializerFactory.shop(guest.getId(), shopDetails, region, shopAddress);
         var savedShop = shopRepository.save(shop);
 
-        var shopWaiting = DataInitializerFactory.shopWaiting(savedUser.getId(), 20, 7, 2);
+        var shopWaiting = DataInitializerFactory.shopWaiting(savedShop.getId(), 20, 7, 2);
         shopWaiting.changeShopWaitingStatus(ShopWaitingStatus.OPEN);
         var savedShopWaiting = shopWaitingRepository.save(shopWaiting);
 
         var waitingPeople = DataInitializerFactory.waitingPeople(2, 0);
-        var waiting = DataInitializerFactory.waiting(savedUser.getId(), shopWaiting, waitingPeople);
+        var waiting = DataInitializerFactory.waiting(savedUser.getId(), savedShopWaiting, waitingPeople);
         var savedWaiting = waitingRepository.save(waiting);
 
         //when
         var waitingDetails = waitingRepository.findByWaitingDetails(savedWaiting.getId()).orElse(null);
 
         //then
+        assertThat(waitingDetails.shopId()).isEqualTo(shop.getId());
         assertThat(waitingDetails.shopName()).isEqualTo(shop.getName());
         assertThat(waitingDetails.region()).isEqualTo(region.getDistrict());
         assertThat(waitingDetails.shopType()).isEqualTo(shop.getShopType());
-        assertThat(waitingDetails.shopDetails()).isEqualTo(shopDetails);
+        assertThat(waitingDetails.shopDetails()).usingRecursiveComparison().isEqualTo(shopDetails);
         assertThat(waitingDetails.waitingNumber()).isEqualTo(waiting.getWaitingNumber());
         assertThat(waitingDetails.waitingStatus()).isEqualTo(waiting.getWaitingStatus());
-        assertThat(waitingDetails.waitingPeople()).isEqualTo(waitingPeople);
+        assertThat(waitingDetails.waitingPeople()).usingRecursiveComparison().isEqualTo(waitingPeople);
         assertThat(waitingDetails.createdDate()).isEqualTo(waiting.getCreatedDate());
         assertThat(waitingDetails.modifiedDate()).isEqualTo(waiting.getModifiedDate());
     }

--- a/src/test/java/com/mdh/devtable/waiting/presentation/UserWaitingControllerTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/presentation/UserWaitingControllerTest.java
@@ -206,7 +206,7 @@ class UserWaitingControllerTest extends RestDocsSupport {
         when(waitingService.findAllByUserIdAndStatus(myWaitingsRequest)).thenReturn(List.of(userWaitingResponse));
 
         //when & then
-        mockMvc.perform(get("/api/customer/v1/waitings/{userId}", 1)
+        mockMvc.perform(get("/api/customer/v1/waitings/me/{userId}", 1)
                         .content(objectMapper.writeValueAsString(myWaitingsRequest))
                         .contentType(MediaType.APPLICATION_JSON))
                 .andDo(print())

--- a/src/test/java/com/mdh/devtable/waiting/presentation/UserWaitingControllerTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/presentation/UserWaitingControllerTest.java
@@ -1,9 +1,12 @@
 package com.mdh.devtable.waiting.presentation;
 
+import com.mdh.devtable.DataInitializerFactory;
 import com.mdh.devtable.RestDocsSupport;
 import com.mdh.devtable.shop.ShopType;
 import com.mdh.devtable.waiting.application.WaitingService;
+import com.mdh.devtable.waiting.application.dto.ShopWaitingResponse;
 import com.mdh.devtable.waiting.application.dto.UserWaitingResponse;
+import com.mdh.devtable.waiting.application.dto.WaitingDetailsResponse;
 import com.mdh.devtable.waiting.domain.WaitingStatus;
 import com.mdh.devtable.waiting.presentation.dto.MyWaitingsRequest;
 import com.mdh.devtable.waiting.presentation.dto.WaitingCreateRequest;
@@ -17,6 +20,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -232,6 +236,69 @@ class UserWaitingControllerTest extends RestDocsSupport {
                                 fieldWithPath("data[].waitingNumber").type(JsonFieldType.NUMBER).description("발급된 웨이팅 번호"),
                                 fieldWithPath("data[].waitingCount").type(JsonFieldType.NUMBER).description("웨이팅 등록 인원 수"),
                                 fieldWithPath("serverDateTime").type(JsonFieldType.STRING).description("생성된 서버 시간")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("웨이팅을 상세 조회한다.")
+    void findWaitingDetailsTest() throws Exception {
+        //given
+        var shopDetails = DataInitializerFactory.shopDetails();
+        var shopWaitingResponse = new ShopWaitingResponse("김밥천국", ShopType.KOREAN, "강남구", shopDetails);
+        var waitingPeople = DataInitializerFactory.waitingPeople(2, 0);
+        var waitingDetailsResponse = new WaitingDetailsResponse(shopWaitingResponse,
+                85,
+                5,
+                WaitingStatus.PROGRESS,
+                waitingPeople,
+                LocalDateTime.of(2023, 9, 8, 16, 0, 0),
+                LocalDateTime.of(2023, 9, 8, 16, 0, 0));
+        var waitingId = 1L;
+        when(waitingService.findWaitingDetails(waitingId)).thenReturn(waitingDetailsResponse);
+
+        //when & then
+        mockMvc.perform(get("/api/customer/v1/waitings/{waitingId}", waitingId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.statusCode").value("200"))
+                .andExpect(jsonPath("$.data.shop.shopName").value(shopWaitingResponse.shopName()))
+                .andExpect(jsonPath("$.data.shop.shopType").value("KOREAN"))
+                .andExpect(jsonPath("$.data.shop.region").value(shopWaitingResponse.region()))
+                .andExpect(jsonPath("$.data.shop.shopDetails.url").value(shopWaitingResponse.shopDetails().getUrl()))
+                .andExpect(jsonPath("$.data.shop.shopDetails.phoneNumber").value(shopDetails.getPhoneNumber()))
+                .andExpect(jsonPath("$.data.shop.shopDetails.introduce").value(shopDetails.getIntroduce()))
+                .andExpect(jsonPath("$.data.shop.shopDetails.openingHours").value(shopDetails.getOpeningHours()))
+                .andExpect(jsonPath("$.data.shop.shopDetails.holiday").value(shopDetails.getHoliday()))
+                .andExpect(jsonPath("$.data.shop.shopDetails.info").value(shopDetails.getInfo()))
+                .andExpect(jsonPath("$.data.waitingNumber").value(85))
+                .andExpect(jsonPath("$.data.waitingRank").value(5))
+                .andExpect(jsonPath("$.data.waitingStatus").value("PROGRESS"))
+                .andExpect(jsonPath("$.data.waitingPeople.adultCount").value(waitingPeople.getAdultCount()))
+                .andExpect(jsonPath("$.data.waitingPeople.childCount").value(waitingPeople.getChildCount()))
+                .andExpect(jsonPath("$.data.createdDate").value("2023-09-08T16:00:00"))
+                .andExpect(jsonPath("$.data.modifiedDate").value("2023-09-08T16:00:00"))
+                .andExpect(jsonPath("$.serverDateTime").exists())
+                .andDo(document("waiting-detail-find",
+                        responseFields(
+                                fieldWithPath("statusCode").type(JsonFieldType.NUMBER).description("상태 코드"),
+                                fieldWithPath("data.shop.shopName").type(JsonFieldType.STRING).description("상점 이름"),
+                                fieldWithPath("data.shop.shopType").type(JsonFieldType.STRING).description("상점 타입"),
+                                fieldWithPath("data.shop.region").type(JsonFieldType.STRING).description("상점 지역"),
+                                fieldWithPath("data.shop.shopDetails.url").type(JsonFieldType.STRING).description("상점 URL"),
+                                fieldWithPath("data.shop.shopDetails.phoneNumber").type(JsonFieldType.STRING).description("상점 전화번호"),
+                                fieldWithPath("data.shop.shopDetails.introduce").type(JsonFieldType.STRING).description("상점 소개"),
+                                fieldWithPath("data.shop.shopDetails.openingHours").type(JsonFieldType.STRING).description("상점 영업 시간"),
+                                fieldWithPath("data.shop.shopDetails.holiday").type(JsonFieldType.STRING).description("상점 휴무일"),
+                                fieldWithPath("data.shop.shopDetails.info").type(JsonFieldType.STRING).description("상점 간단 소개"),
+                                fieldWithPath("data.waitingNumber").type(JsonFieldType.NUMBER).description("대기 번호"),
+                                fieldWithPath("data.waitingRank").type(JsonFieldType.NUMBER).description("대기 순위"),
+                                fieldWithPath("data.waitingStatus").type(JsonFieldType.STRING).description("대기 상태"),
+                                fieldWithPath("data.waitingPeople.adultCount").type(JsonFieldType.NUMBER).description("어른 인원 수"),
+                                fieldWithPath("data.waitingPeople.childCount").type(JsonFieldType.NUMBER).description("유아 인원 수"),
+                                fieldWithPath("data.createdDate").type(JsonFieldType.STRING).description("생성일"),
+                                fieldWithPath("data.modifiedDate").type(JsonFieldType.STRING).description("수정일"),
+                                fieldWithPath("serverDateTime").type(JsonFieldType.STRING).description("서버 시간")
                         )
                 ));
     }


### PR DESCRIPTION
## 🖊️ 1. Changes

- repository에 매장과 조인하여 웨이팅 상세 정보 dto를 Optional로 반환하는 메서드 추가했습니다.
- 웨이팅이 진행 상태일 경우 웨이팅 순위는 null로 반환하도록 했습니다.

## 🖼️ 2. Screenshot
- 웨이팅 서비스 테스트
![waiting service test](https://github.com/prgrms-be-devcourse/BE-04-DevTable/assets/83766322/2470354d-3d4f-4c0f-9485-ecc219ca97c3)

- 웨이팅 컨트롤러 테스트
![waiting detail rest docs](https://github.com/prgrms-be-devcourse/BE-04-DevTable/assets/83766322/f8eaeadd-0748-464f-a0a6-13b342ece2d1)

## ❗️ 3. Issues

1. 로컬에서는 LocalDateTime에 대한 검증이 잘 동작 했지만, github action에서는 실패하였습니다. 
이유는 소수 초를 가지고 있는 LocalDateTime과 달리 **MySQL**의 **DATETIME**은 소수 초를 버린다고 합니다. 
따라서 데이터베이스에 가져온 날짜/시간을 검증할 때 초 단위 내에서 검증하는 것만으로도 충분하다고 합니다.
```java
// 실패한 코드
assertThat(waitingDetails.createdDate()).isEqualTo(waiting.getCreatedDate());
// 성공한 코드
assertThat(waitingDetails.createdDate()).isCloseTo(waiting.getCreatedDate(), within(1, ChronoUnit.SECONDS));
```
3. 

## 😌 4. To Reviewer

-

## ✅ 5. Plans
- [x] - service의 단위 테스트는 이후에 진행하겠습니다.
- [ ] - 