### PR TITLE
[MDH-62] 매장 예약, 예약 도메인 구현 및 테스트

### DIFF
--- a/src/main/java/com/mdh/devtable/reservation/domain/Reservation.java
+++ b/src/main/java/com/mdh/devtable/reservation/domain/Reservation.java
@@ -1,0 +1,66 @@
+package com.mdh.devtable.reservation.domain;
+
+import com.mdh.devtable.global.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "reservations")
+@Entity
+public class Reservation extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "shop_id", nullable = false)
+    private ShopReservation shopReservation;
+
+    @Column(name = "requirement", length = 255, nullable = true)
+    private String requirement;
+
+    @Column(name = "person", nullable = false)
+    private int personCount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 15, nullable = false)
+    private ReservationStatus reservationStatus;
+
+    @Builder
+    public Reservation(
+            Long userId,
+            ShopReservation shopReservation,
+            String requirement,
+            int personCount
+    ) {
+        shopReservation.validPersonCount(personCount);
+        this.userId = userId;
+        this.shopReservation = shopReservation;
+        this.requirement = requirement;
+        this.personCount = personCount;
+        this.reservationStatus = ReservationStatus.CREATED;
+    }
+
+    public void updateReservation(ReservationStatus reservationStatus) {
+        validUpdateReservation(reservationStatus);
+        this.reservationStatus = reservationStatus;
+    }
+
+    private void validUpdateReservation(ReservationStatus reservationStatus) {
+        if (this.reservationStatus == reservationStatus) {
+            throw new IllegalStateException("예약 상태를 동일한 상태로 변경 할 수 없습니다.");
+        }
+
+        if (!this.reservationStatus.isCreated()) {
+            throw new IllegalStateException("예약이 CREATED 상태에서만 상태변경이 가능합니다.");
+        }
+    }
+}

--- a/src/main/java/com/mdh/devtable/reservation/domain/Reservation.java
+++ b/src/main/java/com/mdh/devtable/reservation/domain/Reservation.java
@@ -27,7 +27,7 @@ public class Reservation extends BaseTimeEntity {
     @Column(name = "requirement", length = 255, nullable = true)
     private String requirement;
 
-    @Column(name = "person", nullable = false)
+    @Column(name = "person_count", nullable = false)
     private int personCount;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/mdh/devtable/reservation/domain/ReservationStatus.java
+++ b/src/main/java/com/mdh/devtable/reservation/domain/ReservationStatus.java
@@ -1,0 +1,9 @@
+package com.mdh.devtable.reservation.domain;
+
+public enum ReservationStatus {
+    CREATED, CANCEL, NO_SHOW, VISITED;
+
+    public boolean isCreated() {
+        return this == ReservationStatus.CREATED;
+    }
+}

--- a/src/main/java/com/mdh/devtable/reservation/domain/Seat.java
+++ b/src/main/java/com/mdh/devtable/reservation/domain/Seat.java
@@ -1,4 +1,4 @@
-package com.mdh.devtable.reservation;
+package com.mdh.devtable.reservation.domain;
 
 import com.mdh.devtable.global.BaseTimeEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/mdh/devtable/reservation/domain/SeatStatus.java
+++ b/src/main/java/com/mdh/devtable/reservation/domain/SeatStatus.java
@@ -1,4 +1,4 @@
-package com.mdh.devtable.reservation;
+package com.mdh.devtable.reservation.domain;
 
 public enum SeatStatus {
     AVAILABLE,

--- a/src/main/java/com/mdh/devtable/reservation/domain/SeatType.java
+++ b/src/main/java/com/mdh/devtable/reservation/domain/SeatType.java
@@ -1,4 +1,4 @@
-package com.mdh.devtable.reservation;
+package com.mdh.devtable.reservation.domain;
 
 public enum SeatType {
     ROOM,

--- a/src/main/java/com/mdh/devtable/reservation/domain/ShopReservation.java
+++ b/src/main/java/com/mdh/devtable/reservation/domain/ShopReservation.java
@@ -1,0 +1,60 @@
+package com.mdh.devtable.reservation.domain;
+
+import com.mdh.devtable.global.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "shop_reservations")
+@Entity
+public class ShopReservation extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "shop_id", nullable = false)
+    private Long shopId;
+
+    @Column(name = "minimum_person", nullable = false)
+    private int minimumPerson;
+
+    @Column(name = "maximum_person", nullable = false)
+    private int maximumPerson;
+
+    public ShopReservation(Long shopId, int minimumPerson, int maximumPerson) {
+        validPersonCount(minimumPerson, maximumPerson);
+        this.shopId = shopId;
+        this.minimumPerson = minimumPerson;
+        this.maximumPerson = maximumPerson;
+    }
+
+    private void validPersonCount(int minimumPerson, int maximumPerson) {
+        if (minimumPerson < 1) {
+            throw new IllegalArgumentException("1 보다 작은 수로 최소 인원을 정할 수 없습니다." + minimumPerson);
+        }
+
+        if (maximumPerson > 30) {
+            throw new IllegalArgumentException("30 보다 큰 수로 최대 인원을 정할 수 없습니다." + maximumPerson);
+        }
+
+        if (minimumPerson > maximumPerson) {
+            throw new IllegalArgumentException("최대 인원 수보다 최소 인원 수가 더 클 수 없습니다.");
+        }
+    }
+
+    public void validPersonCount(int personCount) {
+        if (isOutOfRangePersonCount(personCount)) {
+            throw new IllegalArgumentException("예약 인원 수[" + personCount + "]가 매장[" + shopId + "]에서 정한 " +
+                    "최소 최대 인원 범위에서 벗어납니다." +
+                    "[" + minimumPerson + " ~ " + maximumPerson + "]");
+        }
+    }
+
+    private boolean isOutOfRangePersonCount(int personCount) {
+        return this.minimumPerson > personCount || this.maximumPerson < personCount;
+    }
+}

--- a/src/main/java/com/mdh/devtable/reservation/domain/ShopReservationDateTime.java
+++ b/src/main/java/com/mdh/devtable/reservation/domain/ShopReservationDateTime.java
@@ -1,4 +1,4 @@
-package com.mdh.devtable.reservation;
+package com.mdh.devtable.reservation.domain;
 
 import com.mdh.devtable.global.BaseTimeEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/mdh/devtable/reservation/domain/ShopReservationDateTimeSeat.java
+++ b/src/main/java/com/mdh/devtable/reservation/domain/ShopReservationDateTimeSeat.java
@@ -1,4 +1,4 @@
-package com.mdh.devtable.reservation;
+package com.mdh.devtable.reservation.domain;
 
 import com.mdh.devtable.global.BaseTimeEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/mdh/devtable/reservation/infra/persistence/ReservationRepository.java
+++ b/src/main/java/com/mdh/devtable/reservation/infra/persistence/ReservationRepository.java
@@ -1,0 +1,7 @@
+package com.mdh.devtable.reservation.infra.persistence;
+
+import com.mdh.devtable.reservation.domain.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+}

--- a/src/main/java/com/mdh/devtable/reservation/infra/persistence/SeatRepository.java
+++ b/src/main/java/com/mdh/devtable/reservation/infra/persistence/SeatRepository.java
@@ -1,6 +1,6 @@
 package com.mdh.devtable.reservation.infra.persistence;
 
-import com.mdh.devtable.reservation.Seat;
+import com.mdh.devtable.reservation.domain.Seat;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SeatRepository extends JpaRepository<Seat, Long> {

--- a/src/main/java/com/mdh/devtable/reservation/infra/persistence/ShopReservationDateTimeRepository.java
+++ b/src/main/java/com/mdh/devtable/reservation/infra/persistence/ShopReservationDateTimeRepository.java
@@ -1,6 +1,6 @@
 package com.mdh.devtable.reservation.infra.persistence;
 
-import com.mdh.devtable.reservation.ShopReservationDateTime;
+import com.mdh.devtable.reservation.domain.ShopReservationDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ShopReservationDateTimeRepository extends JpaRepository<ShopReservationDateTime, Long> {

--- a/src/main/java/com/mdh/devtable/reservation/infra/persistence/ShopReservationDateTimeSeatRepository.java
+++ b/src/main/java/com/mdh/devtable/reservation/infra/persistence/ShopReservationDateTimeSeatRepository.java
@@ -1,6 +1,6 @@
 package com.mdh.devtable.reservation.infra.persistence;
 
-import com.mdh.devtable.reservation.ShopReservationDateTimeSeat;
+import com.mdh.devtable.reservation.domain.ShopReservationDateTimeSeat;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ShopReservationDateTimeSeatRepository extends JpaRepository<ShopReservationDateTimeSeat, Long> {

--- a/src/main/java/com/mdh/devtable/reservation/infra/persistence/ShopReservationRepository.java
+++ b/src/main/java/com/mdh/devtable/reservation/infra/persistence/ShopReservationRepository.java
@@ -1,0 +1,7 @@
+package com.mdh.devtable.reservation.infra.persistence;
+
+import com.mdh.devtable.reservation.domain.ShopReservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShopReservationRepository extends JpaRepository<ShopReservation, Long> {
+}

--- a/src/test/java/com/mdh/devtable/DataInitializerFactory.java
+++ b/src/test/java/com/mdh/devtable/DataInitializerFactory.java
@@ -1,5 +1,7 @@
 package com.mdh.devtable;
 
+import com.mdh.devtable.reservation.domain.Reservation;
+import com.mdh.devtable.reservation.domain.ShopReservation;
 import com.mdh.devtable.shop.*;
 import com.mdh.devtable.user.domain.Role;
 import com.mdh.devtable.user.domain.User;
@@ -114,4 +116,20 @@ public final class DataInitializerFactory {
                 LocalDateTime.now(),
                 LocalDateTime.now());
     }
+
+    //== 예약 도메인 ==//
+    public static ShopReservation shopReservation(Long shopId, int minimumCount, int maximumCount) {
+        return new ShopReservation(shopId, minimumCount, maximumCount);
+    }
+
+    public static Reservation reservation(Long userId, ShopReservation shopReservation, int personCount) {
+        return Reservation.builder()
+                .userId(userId)
+                .shopReservation(shopReservation)
+                .requirement("요구사항 입니다. 요구 사항은 null 일 수 있습니다.")
+                .personCount(personCount)
+                .build();
+    }
+
+
 }

--- a/src/test/java/com/mdh/devtable/reservation/ShopReservationDateTimeSeatTest.java
+++ b/src/test/java/com/mdh/devtable/reservation/ShopReservationDateTimeSeatTest.java
@@ -1,5 +1,6 @@
 package com.mdh.devtable.reservation;
 
+import com.mdh.devtable.reservation.domain.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/mdh/devtable/reservation/domain/ReservationTest.java
+++ b/src/test/java/com/mdh/devtable/reservation/domain/ReservationTest.java
@@ -1,0 +1,118 @@
+package com.mdh.devtable.reservation.domain;
+
+import com.mdh.devtable.DataInitializerFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReservationTest {
+
+    @Test
+    @DisplayName("예약을 생성 할 수 있다.")
+    void createReservationTest() {
+        //given
+        var shopId = 1L;
+        var minimumCount = 2;
+        var maximumCount = 30;
+        var shopReservation = DataInitializerFactory.shopReservation(shopId, minimumCount, maximumCount);
+
+        var userId = 1L;
+        var personCount = 3;
+
+        //when
+        var reservation = DataInitializerFactory.reservation(userId, shopReservation, personCount);
+
+        //then
+        assertThat(reservation.getReservationStatus()).isEqualTo(ReservationStatus.CREATED);
+        assertThat(reservation.getPersonCount()).isEqualTo(3);
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {"2 30 : 1", "1 10 : 11"}, delimiter = ':')
+    @DisplayName("예약 생성 시 매장의 예약 정보에 있는 최소, 최대 인원수에 벗어나게 예약 할 수 없다.")
+    void createReservationExTest(String shopWaitingInfo, int personCount) {
+        //given
+        var shopId = 1L;
+        var shopWaitingInfos = shopWaitingInfo.split(" ");
+        var minimumCount = Integer.parseInt(shopWaitingInfos[0]);
+        var maximumCount = Integer.parseInt(shopWaitingInfos[1]);
+
+        var shopReservation = DataInitializerFactory.shopReservation(shopId, minimumCount, maximumCount);
+
+        var userId = 1L;
+
+        //when & then
+        assertThatThrownBy(() -> DataInitializerFactory.reservation(userId, shopReservation, personCount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("예약 인원 수[" + personCount + "]가 매장[" + shopId + "]에서 정한 " +
+                        "최소 최대 인원 범위에서 벗어납니다." +
+                        "[" + minimumCount + " ~ " + maximumCount + "]");
+    }
+
+    @ParameterizedTest
+    @DisplayName("예약의 상태를 변경 할 수 있다.")
+    @EnumSource(value = ReservationStatus.class, mode = EnumSource.Mode.EXCLUDE, names = {"CREATED"})
+    void updateReservationStatusTest(ReservationStatus reservationStatus) {
+        //given
+        var shopId = 1L;
+        var minimumCount = 2;
+        var maximumCount = 30;
+        var shopReservation = DataInitializerFactory.shopReservation(shopId, minimumCount, maximumCount);
+
+        var userId = 1L;
+        var personCount = 3;
+        var reservation = DataInitializerFactory.reservation(userId, shopReservation, personCount);
+
+        //when
+        reservation.updateReservation(reservationStatus);
+
+        //then
+        assertThat(reservation.getReservationStatus()).isEqualTo(reservationStatus);
+    }
+
+    @Test
+    @DisplayName("동일한 예약 상태로 변경 할 수 없다.")
+    void updateReservationStatusExTest() {
+        //given
+        var shopId = 1L;
+        var minimumCount = 2;
+        var maximumCount = 30;
+        var shopReservation = DataInitializerFactory.shopReservation(shopId, minimumCount, maximumCount);
+
+        var userId = 1L;
+        var personCount = 3;
+        var reservation = DataInitializerFactory.reservation(userId, shopReservation, personCount);
+
+        //when & then
+        assertThatThrownBy(() -> reservation.updateReservation(ReservationStatus.CREATED))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("예약 상태를 동일한 상태로 변경 할 수 없습니다.");
+    }
+
+    @ParameterizedTest
+    @DisplayName("CREATED 상태가 아닌 예약 상태는 변경 할 수 없다.")
+    @EnumSource(value = ReservationStatus.class, mode = EnumSource.Mode.EXCLUDE, names = {"CREATED"})
+    void updateReservationStatusNotCreatedExTest(ReservationStatus reservationStatus) {
+        //given
+        var shopId = 1L;
+        var minimumCount = 2;
+        var maximumCount = 30;
+        var shopReservation = DataInitializerFactory.shopReservation(shopId, minimumCount, maximumCount);
+
+        var userId = 1L;
+        var personCount = 3;
+        var reservation = DataInitializerFactory.reservation(userId, shopReservation, personCount);
+
+        reservation.updateReservation(reservationStatus);
+
+        //when & then
+        assertThatThrownBy(() -> reservation.updateReservation(ReservationStatus.CREATED))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("예약이 CREATED 상태에서만 상태변경이 가능합니다.");
+    }
+}

--- a/src/test/java/com/mdh/devtable/reservation/domain/ShopReservationTest.java
+++ b/src/test/java/com/mdh/devtable/reservation/domain/ShopReservationTest.java
@@ -1,0 +1,73 @@
+package com.mdh.devtable.reservation.domain;
+
+import com.mdh.devtable.DataInitializerFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ShopReservationTest {
+
+    @Test
+    @DisplayName("매장 예약 사전 정보를 생성 할 수 있다.")
+    void shopReservationTest() {
+        //given
+        var shopId = 1L;
+        var minimumCount = 1;
+        var maximumCount = 30;
+
+
+        // when & then
+        assertThatCode(() -> DataInitializerFactory.shopReservation(shopId, minimumCount, maximumCount))
+                .doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1})
+    @DisplayName("매장 예약 사전 정보 생성 시 최소 인원 수를 0 이하로 설정할 수 없다.")
+    void shopReservationMinimumCountTest(int minimumCount) {
+        //given
+        var shopId = 1L;
+        var maximumCount = 30;
+
+
+        // when & then
+        assertThatThrownBy(() -> DataInitializerFactory.shopReservation(shopId, minimumCount, maximumCount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("1 보다 작은 수로 최소 인원을 정할 수 없습니다." + minimumCount);
+    }
+
+    @Test
+    @DisplayName("매장 예약 사전 정보 생성 시 최대 인원 수가 30을 초과 할 수 없습니다.")
+    void shopReservationMaximumOutOfRangeTest() {
+        //given
+        var shopId = 1L;
+        var minimumCount = 10;
+        var maximumCount = 31;
+
+
+        // when & then
+        assertThatThrownBy(() -> DataInitializerFactory.shopReservation(shopId, minimumCount, maximumCount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("30 보다 큰 수로 최대 인원을 정할 수 없습니다." + maximumCount);
+    }
+
+    @Test
+    @DisplayName("매장 예약 사전 정보 생성 시 최소 인원 수가 최대 인원 수 보다 클 수 없다.")
+    void shopReservationMinimumNoLessThanMaximumTest() {
+        //given
+        var shopId = 1L;
+        var minimumCount = 10;
+        var maximumCount = 5;
+
+
+        // when & then
+        assertThatThrownBy(() -> DataInitializerFactory.shopReservation(shopId, minimumCount, maximumCount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("최대 인원 수보다 최소 인원 수가 더 클 수 없습니다.");
+    }
+
+}


### PR DESCRIPTION
## 🖊️ 1. Changes
- 매장 예약, 예약 도메인을 구현하였습니다.
- 매장 예약, 예약 도메인에 대한 테스트를 구현하였습니다.
- 엔티티 생성 검증을 위한 테스트도 추가하였습니다.

## 🖼️ 2. Screenshot
<img width="562" alt="image" src="https://github.com/prgrms-be-devcourse/BE-04-DevTable/assets/74203371/6ac56bb8-9ae6-4247-a370-764239e35662">


## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer
- personCount에 대한 컬럼명을 person -> person_count 로 변경하였습니다.
- reservation의 도메인들이 domain 패키지 외부에 있어 내부로 통합하였습니다.

## ✅ 5. Plans
