### PR TITLE
[MDH-65] 사용자는 자신이 등록한 웨이팅을 미룰 수 있다.

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -61,6 +61,12 @@ operation::waiting-cancel[snippets = 'http-request,http-response,request-body,re
 
 operation::find-my-waitings[snippets = 'http-request,http-response,request-body,response-fields']
 
+=== 웨이팅 미루기
+
+operation::waiting-postpone[snippets = 'http-request,http-response,request-body,response-fields']
+
+operation::waiting-postpone-notAcceptable[snippets = 'http-request,http-response,request-body,response-fields']
+
 [[Owner-Waiting]]
 == Owner Waiting API
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -10,55 +10,56 @@ endif::[]
 :sectlinks:
 
 [[Dev-Table-API]]
-== Dev Table API
+=== Dev Table API
 
 [[Hello]]
-== Hello Get 요청
+=== Hello Get 요청
 
 operation::hello[snippets = 'http-request,http-response,request-body,response-fields']
 
 [[User]]
-== User 회원가입 요청
+== User API
+
+=== 유저 회원가입 요청
 
 operation::user-sign-up[snippets = 'http-request,http-response,request-body,response-fields']
 
-== User 패스워드 불일치
+=== 유저 패스워드 불일치
 
 operation::user-sign-up-invalid-password-check[snippets = 'http-request,http-response,request-body,response-fields']
 
-== User email 에러
+=== 유저 email 에러
 
 operation::user-sign-up-invalid-email[snippets = 'http-request,http-response,request-body,response-fields']
 
-== User password 에러
+=== 유저 password 에러
 
 operation::user-sign-up-invalid-password[snippets = 'http-request,http-response,request-body,response-fields']
 
-== User phone-number 에러
+=== 유저 phone-number 에러
 
 operation::user-sign-up-invalid-phone-number[snippets = 'http-request,http-response,request-body,response-fields']
 
 [[Waiting]]
-== Waiting 생성
+== Waiting API
+
+=== 웨이팅 생성
 
 operation::waiting-create[snippets = 'http-request,http-response,request-body,response-fields']
 
-== Waiting 생성 허용 범위 예외
+=== 웨이팅 생성 허용 범위 예외
 
 operation::waiting-create-valid-count[snippets = 'http-request,http-response,request-body,response-fields']
 
-== Waiting 입력 값 예외
+=== 웨이팅 입력 값 예외
 
 operation::waiting-create-valid-null[snippets = 'http-request,http-response,request-body,response-fields']
 
-== Waiting 취소
+=== 웨이팅 취소
 
 operation::waiting-cancel[snippets = 'http-request,http-response,request-body,response-fields']
 
-
 operation::find-my-waitings[snippets = 'http-request,http-response,request-body,response-fields']
-
-<<<<<<< HEAD
 
 [[Owner-Waiting]]
 == Owner Waiting API
@@ -89,7 +90,7 @@ operation::owners-shop-waitingInfo[snippets='path-parameters,http-request,http-r
 
 operation::owners-shop-waitingInfo-invalid[snippets='path-parameters,http-request,http-response,request-fields,response-fields']
 
-== Waiting 상세 조회
+=== 웨이팅 상세 조회
 
 operation::waiting-detail-find[snippets = 'http-request,http-response,request-body,response-fields']
 

--- a/src/main/java/com/mdh/devtable/global/handler/GlobalControllerAdvice.java
+++ b/src/main/java/com/mdh/devtable/global/handler/GlobalControllerAdvice.java
@@ -3,6 +3,7 @@ package com.mdh.devtable.global.handler;
 import com.mdh.devtable.global.ApiResponse;
 import com.mdh.devtable.global.error.ValidationError;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import java.net.URI;
 
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalControllerAdvice {
 
@@ -51,6 +53,17 @@ public class GlobalControllerAdvice {
         problemDetail.setInstance(URI.create(uri));
         problemDetail.setTitle("OptimisticLockingFailureException");
 
+        return new ResponseEntity<>(ApiResponse.fail(HttpStatus.BAD_REQUEST.value(), problemDetail), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ApiResponse<ProblemDetail>> handleRuntimeException(RuntimeException e, HttpServletRequest request) {
+        var uri = request.getRequestURI();
+        var problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, e.getMessage());
+        problemDetail.setInstance(URI.create(uri));
+        problemDetail.setTitle("RuntimeException");
+
+        log.warn("런타임 예외가 발생했습니다. {}", e.getMessage(), e);
         return new ResponseEntity<>(ApiResponse.fail(HttpStatus.BAD_REQUEST.value(), problemDetail), HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/com/mdh/devtable/waiting/application/WaitingService.java
+++ b/src/main/java/com/mdh/devtable/waiting/application/WaitingService.java
@@ -79,6 +79,19 @@ public class WaitingService {
         waiting.changeWaitingStatus(WaitingStatus.CANCEL);
     }
 
+    @Transactional
+    public void postPoneWaiting(Long waitingId) {
+        var waiting = waitingRepository.findById(waitingId)
+                .orElseThrow(() -> new NoSuchElementException("등록된 웨이팅이 존재하지 않습니다. waitingId : " + waitingId));
+        var preIssuedTime = waiting.getIssuedTime();
+        var shopId = waiting.getShopWaiting().getShopId();
+
+        if (waitingLine.isPostpone(shopId, waitingId, waiting.getIssuedTime())) {
+            waiting.addPostponedCount();
+            waitingLine.postpone(shopId, waitingId, preIssuedTime, waiting.getIssuedTime());
+        }
+    }
+
     @Transactional(readOnly = true)
     public List<UserWaitingResponse> findAllByUserIdAndStatus(MyWaitingsRequest request) {
 
@@ -90,8 +103,8 @@ public class WaitingService {
 
     private void saveWaitingLine(Long shopId, Waiting savedWaiting) {
         var waitingId = savedWaiting.getId();
-        var createdDate = savedWaiting.getCreatedDate();
-        waitingLine.save(shopId, waitingId, createdDate); // 웨이팅 라인 저장
+        var issuedTime = savedWaiting.getIssuedTime();
+        waitingLine.save(shopId, waitingId, issuedTime); // 웨이팅 라인 저장
     }
 
     private WaitingPeople createWaitingPeople(WaitingCreateRequest waitingCreateRequest) {

--- a/src/main/java/com/mdh/devtable/waiting/application/WaitingService.java
+++ b/src/main/java/com/mdh/devtable/waiting/application/WaitingService.java
@@ -86,10 +86,12 @@ public class WaitingService {
         var preIssuedTime = waiting.getIssuedTime();
         var shopId = waiting.getShopWaiting().getShopId();
 
-        if (waitingLine.isPostpone(shopId, waitingId, waiting.getIssuedTime())) {
-            waiting.addPostponedCount();
-            waitingLine.postpone(shopId, waitingId, preIssuedTime, waiting.getIssuedTime());
+        if (!waitingLine.isPostpone(shopId, waitingId, waiting.getIssuedTime())) {
+            throw new IllegalStateException("미루기를 수행 할 수 없는 웨이팅 입니다. " + waitingId);
         }
+
+        waiting.addPostponedCount();
+        waitingLine.postpone(shopId, waitingId, preIssuedTime, waiting.getIssuedTime());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/mdh/devtable/waiting/domain/Waiting.java
+++ b/src/main/java/com/mdh/devtable/waiting/domain/Waiting.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Table(name = "waitings")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,6 +28,9 @@ public class Waiting extends BaseTimeEntity {
 
     @Column(name = "waiting_number", nullable = false)
     private int waitingNumber;
+
+    @Column(name = "issued_time", nullable = false)
+    private LocalDateTime issuedTime;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "waiting_status", length = 31, nullable = false)
@@ -48,6 +53,7 @@ public class Waiting extends BaseTimeEntity {
         this.shopWaiting = shopWaiting;
         this.userId = userId;
         this.waitingNumber = shopWaiting.getWaitingCount();
+        this.issuedTime = LocalDateTime.now();
         this.waitingStatus = WaitingStatus.PROGRESS;
         this.postponedCount = 0;
         this.waitingPeople = waitingPeople;
@@ -75,6 +81,7 @@ public class Waiting extends BaseTimeEntity {
             throw new IllegalStateException("웨이팅 미루기는 2회 초과하여 불가능 합니다.");
         }
         postponedCount++;
+        this.issuedTime = LocalDateTime.now();
     }
 
     private boolean isProgress() {

--- a/src/main/java/com/mdh/devtable/waiting/infra/persistence/PlainWaitingLine.java
+++ b/src/main/java/com/mdh/devtable/waiting/infra/persistence/PlainWaitingLine.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.Map;
-import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -14,22 +13,21 @@ import java.util.concurrent.ConcurrentHashMap;
 public class PlainWaitingLine implements WaitingLine {
 
     // 매장의 아이디, 매장의 웨이팅 라인
-    private final Map<Long, SortedSet<WaitingInfo>> waitingLine = new ConcurrentHashMap<>();
+    private final Map<Long, TreeSet<WaitingInfo>> waitingLine = new ConcurrentHashMap<>();
 
     @Override
-    public void save(Long shopId, Long waitingId, LocalDateTime createdDate) {
-        // 해당 매장에 대한 라인이 없다면
+    public void save(Long shopId, Long waitingId, LocalDateTime issuedTime) {
         waitingLine.putIfAbsent(shopId,
                 new TreeSet<>(Comparator.comparing(WaitingInfo::waitingStartTime)));
 
-        var waitingInfo = new WaitingInfo(waitingId, createdDate);
+        var waitingInfo = new WaitingInfo(waitingId, issuedTime);
         var waitingInfos = waitingLine.get(shopId);
         waitingInfos.add(waitingInfo);
     }
 
     @Override
-    public int findRank(Long shopId, Long waitingId, LocalDateTime createdDate) {
-        var waitingInfo = new WaitingInfo(waitingId, createdDate);
+    public int findRank(Long shopId, Long waitingId, LocalDateTime issuedTime) {
+        var waitingInfo = new WaitingInfo(waitingId, issuedTime);
         var waitingInfos = waitingLine.get(shopId);
 
         return waitingInfos.headSet(waitingInfo).size() + 1;
@@ -41,14 +39,40 @@ public class PlainWaitingLine implements WaitingLine {
         return waitingInfos.size();
     }
 
-    public void cancel(Long shopId, Long waitingId, LocalDateTime createdDate) {
-        if (!waitingLine.containsKey(shopId)) {
-            throw new IllegalStateException("현재 매장에 등록 된 웨이팅이 아닙니다. shopId : " + shopId + "waitingId : " + waitingId);
-        }
+    @Override
+    public void cancel(Long shopId, Long waitingId, LocalDateTime issuedTime) {
+        var waitingInfo = new WaitingInfo(waitingId, issuedTime);
+        validExistWaiting(shopId, waitingInfo);
 
-        var waitingInfo = new WaitingInfo(waitingId, createdDate);
         var waitingInfos = waitingLine.get(shopId);
         waitingInfos.remove(waitingInfo);
 
+    }
+
+    private void validExistWaiting(Long shopId, WaitingInfo waitingInfo) {
+        if (!waitingLine.containsKey(shopId)) {
+            throw new IllegalStateException("현재 매장에 등록 된 웨이팅이 아닙니다. shopId : " + shopId +
+                    "waitingId : " + waitingInfo.waitingId());
+        }
+
+        if (!waitingLine.get(shopId).contains(waitingInfo)) {
+            throw new IllegalStateException("현재 매장에 등록 된 웨이팅이 아닙니다. shopId : " + shopId +
+                    "waitingId : " + waitingInfo.waitingId());
+        }
+    }
+
+    @Override
+    public void postpone(Long shopId, Long waitingId, LocalDateTime preIssuedTime, LocalDateTime issuedTime) {
+        var waitingInfo = new WaitingInfo(waitingId, preIssuedTime);
+        validExistWaiting(shopId, waitingInfo);
+
+        var waitingInfos = waitingLine.get(shopId);
+        waitingInfos.remove(waitingInfo);
+        waitingInfos.add(new WaitingInfo(waitingId, issuedTime));
+    }
+
+    @Override
+    public boolean isPostpone(Long shopId, Long waitingId, LocalDateTime issuedTime) {
+        return findRank(shopId, waitingId, issuedTime) != findTotalWaiting(shopId);
     }
 }

--- a/src/main/java/com/mdh/devtable/waiting/infra/persistence/WaitingLine.java
+++ b/src/main/java/com/mdh/devtable/waiting/infra/persistence/WaitingLine.java
@@ -4,11 +4,15 @@ import java.time.LocalDateTime;
 
 public interface WaitingLine {
 
-    void save(Long shopId, Long waitingId, LocalDateTime createdDate);
+    void save(Long shopId, Long waitingId, LocalDateTime issuedTime);
 
-    int findRank(Long shopId, Long waitingId, LocalDateTime createdDate);
+    int findRank(Long shopId, Long waitingId, LocalDateTime issuedTime);
 
     int findTotalWaiting(Long shopId);
-  
-    void cancel(Long shopId, Long waitingId, LocalDateTime createdDate);
+
+    void cancel(Long shopId, Long waitingId, LocalDateTime issuedTime);
+
+    void postpone(Long shopId, Long waitingId, LocalDateTime preIssuedTime, LocalDateTime issuedTime);
+
+    boolean isPostpone(Long shopId, Long waitingId, LocalDateTime issuedTime);
 }

--- a/src/main/java/com/mdh/devtable/waiting/infra/persistence/dto/WaitingInfo.java
+++ b/src/main/java/com/mdh/devtable/waiting/infra/persistence/dto/WaitingInfo.java
@@ -3,7 +3,8 @@ package com.mdh.devtable.waiting.infra.persistence.dto;
 import java.time.LocalDateTime;
 
 public record WaitingInfo(
-    Long waitingId,
-    LocalDateTime waitingStartTime
+        Long waitingId,
+        LocalDateTime waitingStartTime
 ) {
+    
 }

--- a/src/main/java/com/mdh/devtable/waiting/presentation/UserWaitingController.java
+++ b/src/main/java/com/mdh/devtable/waiting/presentation/UserWaitingController.java
@@ -46,4 +46,10 @@ public class UserWaitingController {
         var waitingDetailsResponse = waitingService.findWaitingDetails(waitingId);
         return new ResponseEntity<>(ApiResponse.ok(waitingDetailsResponse), HttpStatus.OK);
     }
+
+    @PatchMapping("/{waitingId}/postpone")
+    public ResponseEntity<ApiResponse<Void>> postponeWaiting(@PathVariable Long waitingId) {
+        waitingService.postPoneWaiting(waitingId);
+        return new ResponseEntity<>(ApiResponse.ok(null), HttpStatus.OK);
+    }
 }

--- a/src/test/java/com/mdh/devtable/waiting/WaitingLineTest.java
+++ b/src/test/java/com/mdh/devtable/waiting/WaitingLineTest.java
@@ -51,14 +51,14 @@ class WaitingLineTest {
         waitingLine.save(shopId, waitingId1, waitingId1Time);
         waitingLine.save(shopId, waitingId2, waitingId2Time);
         waitingLine.save(shopId, waitingId3, waitingId3Time);
-    
+
         //when
         var totalWaiting = waitingLine.findTotalWaiting(shopId);
-      
+
         //then
         assertThat(totalWaiting).isEqualTo(3);
     }
-  
+
     @DisplayName("매장에서 웨이팅이 취소가 되면 순위가 변경된다.")
     void cancelWaitingTest() {
         //given
@@ -96,5 +96,54 @@ class WaitingLineTest {
         assertThatThrownBy(() -> waitingLine.cancel(shopId, waitingId, waitingTime))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("현재 매장에 등록 된 웨이팅이 아닙니다. shopId : " + shopId + "waitingId : " + waitingId);
+    }
+
+    @Test
+    @DisplayName("매장에 등록된 웨이팅을 맨 뒤로 미룰 수 있다.")
+    void postponeWaitingTest() {
+        //given
+        var shopId = 1L;
+        var waitingId1 = 1L;
+        var waitingId1Time = LocalDateTime.now();
+        var waitingId2 = 2L;
+        var waitingId2Time = waitingId1Time.plusMinutes(1);
+        var waitingId3 = 3L;
+        var waitingId3Time = waitingId2Time.plusMinutes(2);
+
+        var waitingLine = new PlainWaitingLine();
+        waitingLine.save(shopId, waitingId1, waitingId1Time);
+        waitingLine.save(shopId, waitingId2, waitingId2Time);
+        waitingLine.save(shopId, waitingId3, waitingId3Time);
+
+        //when
+        waitingLine.postpone(shopId, waitingId1, waitingId1Time, waitingId3Time.plusMinutes(1));
+        var findWaiting = waitingLine.findRank(shopId, waitingId1, waitingId3Time.plusMinutes(1));
+
+        //then
+        assertThat(findWaiting).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("맨 뒤에 있는 웨이팅은 미룰 수 없다.")
+    void postponeWaitingFailTest() {
+        //given
+        var shopId = 1L;
+        var waitingId1 = 1L;
+        var waitingId1Time = LocalDateTime.now();
+        var waitingId2 = 2L;
+        var waitingId2Time = waitingId1Time.plusMinutes(1);
+        var waitingId3 = 3L;
+        var waitingId3Time = waitingId2Time.plusMinutes(2);
+
+        var waitingLine = new PlainWaitingLine();
+        waitingLine.save(shopId, waitingId1, waitingId1Time);
+        waitingLine.save(shopId, waitingId2, waitingId2Time);
+        waitingLine.save(shopId, waitingId3, waitingId3Time);
+
+        //when
+        var isPostpone = waitingLine.isPostpone(shopId, waitingId3, waitingId3Time);
+
+        //then
+        assertThat(isPostpone).isEqualTo(false);
     }
 }


### PR DESCRIPTION
## 🖊️ 1. Changes
- 웨이팅 미루기 기능을 구현하였습니다.
- 웨이팅 미루기 기능을 구현하기 위해 웨이팅 Entity에 issuedTime 필드가 추가되었습니다.
- 기존의 SortedSet으로 되어있던 부분을 구성클래스인 TreeSet으로 변경하였습니다.
  - 디버깅을 진행 중에 DescendingIterator 부분이 없어서 변경하게 되었습니다. 
- 웨이팅 미루기에 대한 엔드포인트와 테스트 코드를 작성하였습니다.
- RuntimeException에 대한 @ConrollerAdvice를 추가하였습니다.
- index.adoc의 컨벤션이 일치하지 않아 모든 내용을 통일하였습니다.

## 🖼️ 2. Screenshot
<img width="339" alt="image" src="https://github.com/prgrms-be-devcourse/BE-04-DevTable/assets/74203371/2b656a28-83b9-4caf-8dac-8c0c45e6b19b">

<img width="479" alt="image" src="https://github.com/prgrms-be-devcourse/BE-04-DevTable/assets/74203371/adfa3d48-ea34-45ee-8435-9dcd3bfd4fcb">

![image](https://github.com/prgrms-be-devcourse/BE-04-DevTable/assets/74203371/f4c00ac9-bfdd-49cf-b5e2-6894e725d53d)

![image](https://github.com/prgrms-be-devcourse/BE-04-DevTable/assets/74203371/e08e9343-9435-4a44-a3fb-074976d334fe)

![image](https://github.com/prgrms-be-devcourse/BE-04-DevTable/assets/74203371/e94a6837-acac-4aae-abca-ced9b4f6fee0)

## ❗️ 3. Issues

1. 기존에 modifiedDate 및 createdDate를 사용하여 데이터를 정렬하는데 데이터의 정합성 문제가 발생하였습니다. 이를 해결 하기위해 issuedTime 필드를 추가하여 해당 필드는 애플리케이션의 서버 시간과 일치시켜 데이터의 정합성을 일치시켜 탐색 할 수 있도록 하였습니다.
2. 변경 내용에 대해 push 를 하고 내부에 있는 commit을 amend 하다가 commit 내용이 꼬였네요..! 다음에는 이런 상황에서 force push를 하도록하여 변경점이 없도록 하겠습니다.

## 😌 4. To Reviewer

-

## ✅ 5. Plans
- [x] - 웨이팅 미루기 api 및 rest docs를 추가
