### PR TITLE
[MDH-61] 사용자의 예약 등록

### DIFF
--- a/src/main/java/com/mdh/devtable/reservation/application/ReservationService.java
+++ b/src/main/java/com/mdh/devtable/reservation/application/ReservationService.java
@@ -4,13 +4,9 @@ import com.mdh.devtable.reservation.controller.dto.ReservationCreateRequest;
 import com.mdh.devtable.reservation.domain.Reservation;
 import com.mdh.devtable.reservation.domain.ShopReservation;
 import com.mdh.devtable.reservation.infra.persistence.ReservationRepository;
-import com.mdh.devtable.reservation.infra.persistence.ShopReservationDateTimeSeatRepository;
-import com.mdh.devtable.reservation.infra.persistence.ShopReservationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.NoSuchElementException;
 
 @Service
 @RequiredArgsConstructor
@@ -18,22 +14,14 @@ public class ReservationService {
 
     private final ReservationRepository reservationRepository;
 
-    private final ShopReservationRepository shopReservationRepository;
-
-    private final ShopReservationDateTimeSeatRepository shopReservationDateTimeSeatRepository;
+    private final ReservationValidator reservationValidator;
 
     @Transactional
     public void createReservation(ReservationCreateRequest reservationCreateRequest) {
         var shopId = reservationCreateRequest.shopId();
 
-        var shopReservation = shopReservationRepository.findById(shopId)
-                .orElseThrow(() -> new NoSuchElementException("매장의 예약 정보가 없습니다. shopId " + shopId));
-
-        var shopReservationDateTimeSeats = reservationCreateRequest.shopReservationDateTimeSeatIds().stream()
-                .map(shopReservationDateTimeSeatId ->
-                        shopReservationDateTimeSeatRepository.findById(shopReservationDateTimeSeatId)
-                                .orElseThrow(() -> new NoSuchElementException("예약 좌석 정보가 없습니다. shopReservationDateTimeSeatId : " + shopReservationDateTimeSeatId)))
-                .toList();
+        var shopReservation = reservationValidator.validShopReservation(shopId);
+        var shopReservationDateTimeSeats = reservationValidator.validShopReservationDateTimeSeats(reservationCreateRequest.shopReservationDateTimeSeatIds());
 
         var reservation = saveReservation(reservationCreateRequest, shopReservation);
         var size = shopReservationDateTimeSeats.size();

--- a/src/main/java/com/mdh/devtable/reservation/application/ReservationService.java
+++ b/src/main/java/com/mdh/devtable/reservation/application/ReservationService.java
@@ -1,0 +1,55 @@
+package com.mdh.devtable.reservation.application;
+
+import com.mdh.devtable.reservation.controller.dto.ReservationCreateRequest;
+import com.mdh.devtable.reservation.domain.Reservation;
+import com.mdh.devtable.reservation.domain.ShopReservation;
+import com.mdh.devtable.reservation.infra.persistence.ReservationRepository;
+import com.mdh.devtable.reservation.infra.persistence.ShopReservationDateTimeSeatRepository;
+import com.mdh.devtable.reservation.infra.persistence.ShopReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationService {
+
+    private final ReservationRepository reservationRepository;
+
+    private final ShopReservationRepository shopReservationRepository;
+
+    private final ShopReservationDateTimeSeatRepository shopReservationDateTimeSeatRepository;
+
+    @Transactional
+    public void createReservation(ReservationCreateRequest reservationCreateRequest) {
+        var shopId = reservationCreateRequest.shopId();
+
+        var shopReservation = shopReservationRepository.findById(shopId)
+                .orElseThrow(() -> new NoSuchElementException("매장의 예약 정보가 없습니다. shopId " + shopId));
+
+        var shopReservationDateTimeSeats = reservationCreateRequest.shopReservationDateTimeSeatIds().stream()
+                .map(shopReservationDateTimeSeatId ->
+                        shopReservationDateTimeSeatRepository.findById(shopReservationDateTimeSeatId)
+                                .orElseThrow(() -> new NoSuchElementException("예약 좌석 정보가 없습니다. shopReservationDateTimeSeatId : " + shopReservationDateTimeSeatId)))
+                .toList();
+
+        var reservation = saveReservation(reservationCreateRequest, shopReservation);
+        var size = shopReservationDateTimeSeats.size();
+        if (!reservation.isSeatsSizeUnderOrSamePersonCount(size)) {
+            throw new IllegalArgumentException("예약하려는 좌석의 수가 예약 인원 수를 초과했습니다. seats size : " + size + ", person count : " + reservation.getPersonCount());
+        }
+
+        shopReservationDateTimeSeats.forEach(shopReservationDateTimeSeat ->
+                shopReservationDateTimeSeat.registerReservation(reservation));
+    }
+
+    private Reservation saveReservation(ReservationCreateRequest reservationCreateRequest, ShopReservation shopReservation) {
+        var reservation = new Reservation(reservationCreateRequest.userId(),
+                shopReservation,
+                reservationCreateRequest.requirement(),
+                reservationCreateRequest.person_count());
+        return reservationRepository.save(reservation);
+    }
+}

--- a/src/main/java/com/mdh/devtable/reservation/application/ReservationValidator.java
+++ b/src/main/java/com/mdh/devtable/reservation/application/ReservationValidator.java
@@ -1,0 +1,34 @@
+package com.mdh.devtable.reservation.application;
+
+import com.mdh.devtable.reservation.domain.ShopReservation;
+import com.mdh.devtable.reservation.domain.ShopReservationDateTimeSeat;
+import com.mdh.devtable.reservation.infra.persistence.ShopReservationDateTimeSeatRepository;
+import com.mdh.devtable.reservation.infra.persistence.ShopReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Component
+public class ReservationValidator {
+
+    private final ShopReservationRepository shopReservationRepository;
+    private final ShopReservationDateTimeSeatRepository shopReservationDateTimeSeatRepository;
+
+    public ShopReservation validShopReservation(Long shopId) {
+        return shopReservationRepository.findById(shopId)
+                .orElseThrow(() -> new NoSuchElementException("매장의 예약 정보가 없습니다. shopId " + shopId));
+    }
+
+    public List<ShopReservationDateTimeSeat> validShopReservationDateTimeSeats(List<Long> shopReservationDateTimeSeatIds) {
+        return shopReservationDateTimeSeatIds.stream()
+                .map(shopReservationDateTimeSeatId ->
+                        shopReservationDateTimeSeatRepository.findById(shopReservationDateTimeSeatId)
+                                .orElseThrow(() -> new NoSuchElementException("예약 좌석 정보가 없습니다. shopReservationDateTimeSeatId : " + shopReservationDateTimeSeatId)))
+                .toList();
+    }
+}

--- a/src/main/java/com/mdh/devtable/reservation/controller/dto/ReservationCreateRequest.java
+++ b/src/main/java/com/mdh/devtable/reservation/controller/dto/ReservationCreateRequest.java
@@ -1,0 +1,12 @@
+package com.mdh.devtable.reservation.controller.dto;
+
+import java.util.List;
+
+public record ReservationCreateRequest(
+        Long userId,
+        Long shopId,
+        List<Long> shopReservationDateTimeSeatIds,
+        String requirement,
+        int person_count
+) {
+}

--- a/src/main/java/com/mdh/devtable/reservation/domain/Reservation.java
+++ b/src/main/java/com/mdh/devtable/reservation/domain/Reservation.java
@@ -49,6 +49,10 @@ public class Reservation extends BaseTimeEntity {
         this.reservationStatus = ReservationStatus.CREATED;
     }
 
+    public boolean isSeatsSizeUnderOrSamePersonCount(int size) {
+        return size <= personCount;
+    }
+
     public void updateReservation(ReservationStatus reservationStatus) {
         validUpdateReservation(reservationStatus);
         this.reservationStatus = reservationStatus;

--- a/src/test/java/com/mdh/devtable/DataInitializerFactory.java
+++ b/src/test/java/com/mdh/devtable/DataInitializerFactory.java
@@ -1,7 +1,6 @@
 package com.mdh.devtable;
 
-import com.mdh.devtable.reservation.domain.Reservation;
-import com.mdh.devtable.reservation.domain.ShopReservation;
+import com.mdh.devtable.reservation.domain.*;
 import com.mdh.devtable.shop.*;
 import com.mdh.devtable.user.domain.Role;
 import com.mdh.devtable.user.domain.User;
@@ -11,7 +10,9 @@ import com.mdh.devtable.waiting.domain.WaitingPeople;
 import com.mdh.devtable.waiting.domain.WaitingStatus;
 import com.mdh.devtable.waiting.infra.persistence.dto.WaitingDetails;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 public final class DataInitializerFactory {
 
@@ -131,5 +132,16 @@ public final class DataInitializerFactory {
                 .build();
     }
 
+    public static Seat seat(ShopReservation shopReservation) {
+        return new Seat(shopReservation, SeatType.ROOM);
+    }
 
+    public static ShopReservationDateTime shopReservationDateTime(ShopReservation shopReservation) {
+        return new ShopReservationDateTime(shopReservation, LocalDate.now(), LocalTime.now());
+    }
+
+    public static ShopReservationDateTimeSeat shopReservationDateTimeSeat(ShopReservationDateTime shopReservationDateTime,
+                                                                          Seat seat) {
+        return new ShopReservationDateTimeSeat(shopReservationDateTime, seat);
+    }
 }

--- a/src/test/java/com/mdh/devtable/reservation/application/ReservationServiceTest.java
+++ b/src/test/java/com/mdh/devtable/reservation/application/ReservationServiceTest.java
@@ -4,8 +4,6 @@ import com.mdh.devtable.DataInitializerFactory;
 import com.mdh.devtable.reservation.controller.dto.ReservationCreateRequest;
 import com.mdh.devtable.reservation.domain.Reservation;
 import com.mdh.devtable.reservation.infra.persistence.ReservationRepository;
-import com.mdh.devtable.reservation.infra.persistence.ShopReservationDateTimeSeatRepository;
-import com.mdh.devtable.reservation.infra.persistence.ShopReservationRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,11 +12,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -33,10 +30,7 @@ class ReservationServiceTest {
     private ReservationRepository reservationRepository;
 
     @Mock
-    private ShopReservationRepository shopReservationRepository;
-
-    @Mock
-    private ShopReservationDateTimeSeatRepository shopReservationDateTimeSeatRepository;
+    private ReservationValidator reservationValidator;
 
     @Test
     @DisplayName("예약을 등록한다.")
@@ -48,25 +42,20 @@ class ReservationServiceTest {
 
         var shopReservationDateTime = DataInitializerFactory.shopReservationDateTime(shopReservation);
 
-        var shopReservationDateTimeSeatId1 = 3L;
         var shopReservationDateTimeSeat1 = DataInitializerFactory.shopReservationDateTimeSeat(shopReservationDateTime, seat);
-        var shopReservationDateTimeSeatId2 = 4L;
         var shopReservationDateTimeSeat2 = DataInitializerFactory.shopReservationDateTimeSeat(shopReservationDateTime, seat);
 
         var reservation = DataInitializerFactory.reservation(1L, shopReservation, 3);
 
-        given(shopReservationRepository.findById(any(Long.class)))
-                .willReturn(Optional.ofNullable(shopReservation));
-        given(shopReservationDateTimeSeatRepository.findById(shopReservationDateTimeSeatId1))
-                .willReturn(Optional.ofNullable(shopReservationDateTimeSeat1));
-        given(shopReservationDateTimeSeatRepository.findById(shopReservationDateTimeSeatId2))
-                .willReturn(Optional.ofNullable(shopReservationDateTimeSeat2));
+        given(reservationValidator.validShopReservation(any(Long.class))).willReturn(shopReservation);
+        given(reservationValidator.validShopReservationDateTimeSeats(anyList()))
+                .willReturn(List.of(shopReservationDateTimeSeat1, shopReservationDateTimeSeat2));
         given(reservationRepository.save(any(Reservation.class)))
                 .willReturn(reservation);
 
         var reservationCreateRequest = new ReservationCreateRequest(1L,
                 2L,
-                List.of(shopReservationDateTimeSeatId1, shopReservationDateTimeSeatId2),
+                List.of(3L, 4L),
                 "요구사항 입니다.",
                 2);
 
@@ -74,54 +63,9 @@ class ReservationServiceTest {
         reservationService.createReservation(reservationCreateRequest);
 
         //then
-        verify(shopReservationRepository, times(1)).findById(any(Long.class));
-        verify(shopReservationDateTimeSeatRepository, times(2)).findById(any(Long.class));
+        verify(reservationValidator, times(1)).validShopReservation(any(Long.class));
+        verify(reservationValidator, times(1)).validShopReservationDateTimeSeats(anyList());
         verify(reservationRepository, times(1)).save(any(Reservation.class));
-    }
-
-    @Test
-    @DisplayName("해당 매장의 예약 정보가 없다면 예외가 발생한다.")
-    void createReservationNoSuchShopReservationExTest() {
-        //given
-        var shopId = 1L;
-
-        given(shopReservationRepository.findById(any(Long.class)))
-                .willReturn(Optional.empty());
-
-        var reservationCreateRequest = new ReservationCreateRequest(1L,
-                shopId,
-                List.of(3L, 4L, 5L),
-                "요구사항 입니다.",
-                2);
-
-        //when&then
-        assertThatThrownBy(() -> reservationService.createReservation(reservationCreateRequest))
-                .isInstanceOf(NoSuchElementException.class)
-                .hasMessage("매장의 예약 정보가 없습니다. shopId " + shopId);
-    }
-
-    @Test
-    @DisplayName("해당 예약 좌석이 없다면 예외가 발생한다.")
-    void ecreateReservationTest() {
-        //given
-        var shopReservation = DataInitializerFactory.shopReservation(1L, 2, 10);
-        var shopReservationDateTimeSeatId = 3L;
-
-        given(shopReservationRepository.findById(any(Long.class)))
-                .willReturn(Optional.ofNullable(shopReservation));
-        given(shopReservationDateTimeSeatRepository.findById(any(Long.class)))
-                .willReturn(Optional.empty());
-
-        var reservationCreateRequest = new ReservationCreateRequest(1L,
-                2L,
-                List.of(shopReservationDateTimeSeatId, 4L, 5L),
-                "요구사항 입니다.",
-                2);
-
-        //when&then
-        assertThatThrownBy(() -> reservationService.createReservation(reservationCreateRequest))
-                .isInstanceOf(NoSuchElementException.class)
-                .hasMessage("예약 좌석 정보가 없습니다. shopReservationDateTimeSeatId : " + shopReservationDateTimeSeatId);
     }
 
     @Test
@@ -129,15 +73,20 @@ class ReservationServiceTest {
     void createReservationeTest() {
         //given
         var shopReservation = DataInitializerFactory.shopReservation(1L, 2, 10);
+
         var seat = DataInitializerFactory.seat(shopReservation);
+
         var shopReservationDateTime = DataInitializerFactory.shopReservationDateTime(shopReservation);
-        var shopReservationDateTimeSeat = DataInitializerFactory.shopReservationDateTimeSeat(shopReservationDateTime, seat);
+
+        var shopReservationDateTimeSeat1 = DataInitializerFactory.shopReservationDateTimeSeat(shopReservationDateTime, seat);
+        var shopReservationDateTimeSeat2 = DataInitializerFactory.shopReservationDateTimeSeat(shopReservationDateTime, seat);
+        var shopReservationDateTimeSeat3 = DataInitializerFactory.shopReservationDateTimeSeat(shopReservationDateTime, seat);
+
         var reservation = DataInitializerFactory.reservation(1L, shopReservation, 2);
 
-        given(shopReservationRepository.findById(any(Long.class)))
-                .willReturn(Optional.ofNullable(shopReservation));
-        given(shopReservationDateTimeSeatRepository.findById(any(Long.class)))
-                .willReturn(Optional.ofNullable(shopReservationDateTimeSeat));
+        given(reservationValidator.validShopReservation(any(Long.class))).willReturn(shopReservation);
+        given(reservationValidator.validShopReservationDateTimeSeats(anyList()))
+                .willReturn(List.of(shopReservationDateTimeSeat1, shopReservationDateTimeSeat2, shopReservationDateTimeSeat3));
         given(reservationRepository.save(any(Reservation.class)))
                 .willReturn(reservation);
 

--- a/src/test/java/com/mdh/devtable/reservation/application/ReservationServiceTest.java
+++ b/src/test/java/com/mdh/devtable/reservation/application/ReservationServiceTest.java
@@ -1,0 +1,158 @@
+package com.mdh.devtable.reservation.application;
+
+import com.mdh.devtable.DataInitializerFactory;
+import com.mdh.devtable.reservation.controller.dto.ReservationCreateRequest;
+import com.mdh.devtable.reservation.domain.Reservation;
+import com.mdh.devtable.reservation.infra.persistence.ReservationRepository;
+import com.mdh.devtable.reservation.infra.persistence.ShopReservationDateTimeSeatRepository;
+import com.mdh.devtable.reservation.infra.persistence.ShopReservationRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationServiceTest {
+
+    @InjectMocks
+    private ReservationService reservationService;
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @Mock
+    private ShopReservationRepository shopReservationRepository;
+
+    @Mock
+    private ShopReservationDateTimeSeatRepository shopReservationDateTimeSeatRepository;
+
+    @Test
+    @DisplayName("예약을 등록한다.")
+    void createReservationTest() {
+        //given
+        var shopReservation = DataInitializerFactory.shopReservation(1L, 2, 10);
+
+        var seat = DataInitializerFactory.seat(shopReservation);
+
+        var shopReservationDateTime = DataInitializerFactory.shopReservationDateTime(shopReservation);
+
+        var shopReservationDateTimeSeatId1 = 3L;
+        var shopReservationDateTimeSeat1 = DataInitializerFactory.shopReservationDateTimeSeat(shopReservationDateTime, seat);
+        var shopReservationDateTimeSeatId2 = 4L;
+        var shopReservationDateTimeSeat2 = DataInitializerFactory.shopReservationDateTimeSeat(shopReservationDateTime, seat);
+
+        var reservation = DataInitializerFactory.reservation(1L, shopReservation, 3);
+
+        given(shopReservationRepository.findById(any(Long.class)))
+                .willReturn(Optional.ofNullable(shopReservation));
+        given(shopReservationDateTimeSeatRepository.findById(shopReservationDateTimeSeatId1))
+                .willReturn(Optional.ofNullable(shopReservationDateTimeSeat1));
+        given(shopReservationDateTimeSeatRepository.findById(shopReservationDateTimeSeatId2))
+                .willReturn(Optional.ofNullable(shopReservationDateTimeSeat2));
+        given(reservationRepository.save(any(Reservation.class)))
+                .willReturn(reservation);
+
+        var reservationCreateRequest = new ReservationCreateRequest(1L,
+                2L,
+                List.of(shopReservationDateTimeSeatId1, shopReservationDateTimeSeatId2),
+                "요구사항 입니다.",
+                2);
+
+        //when
+        reservationService.createReservation(reservationCreateRequest);
+
+        //then
+        verify(shopReservationRepository, times(1)).findById(any(Long.class));
+        verify(shopReservationDateTimeSeatRepository, times(2)).findById(any(Long.class));
+        verify(reservationRepository, times(1)).save(any(Reservation.class));
+    }
+
+    @Test
+    @DisplayName("해당 매장의 예약 정보가 없다면 예외가 발생한다.")
+    void createReservationNoSuchShopReservationExTest() {
+        //given
+        var shopId = 1L;
+
+        given(shopReservationRepository.findById(any(Long.class)))
+                .willReturn(Optional.empty());
+
+        var reservationCreateRequest = new ReservationCreateRequest(1L,
+                shopId,
+                List.of(3L, 4L, 5L),
+                "요구사항 입니다.",
+                2);
+
+        //when&then
+        assertThatThrownBy(() -> reservationService.createReservation(reservationCreateRequest))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage("매장의 예약 정보가 없습니다. shopId " + shopId);
+    }
+
+    @Test
+    @DisplayName("해당 예약 좌석이 없다면 예외가 발생한다.")
+    void ecreateReservationTest() {
+        //given
+        var shopReservation = DataInitializerFactory.shopReservation(1L, 2, 10);
+        var shopReservationDateTimeSeatId = 3L;
+
+        given(shopReservationRepository.findById(any(Long.class)))
+                .willReturn(Optional.ofNullable(shopReservation));
+        given(shopReservationDateTimeSeatRepository.findById(any(Long.class)))
+                .willReturn(Optional.empty());
+
+        var reservationCreateRequest = new ReservationCreateRequest(1L,
+                2L,
+                List.of(shopReservationDateTimeSeatId, 4L, 5L),
+                "요구사항 입니다.",
+                2);
+
+        //when&then
+        assertThatThrownBy(() -> reservationService.createReservation(reservationCreateRequest))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage("예약 좌석 정보가 없습니다. shopReservationDateTimeSeatId : " + shopReservationDateTimeSeatId);
+    }
+
+    @Test
+    @DisplayName("예약하려는 좌석들의 수가 예약 인원 수를 넘어가면 예외가 발생한다.")
+    void createReservationeTest() {
+        //given
+        var shopReservation = DataInitializerFactory.shopReservation(1L, 2, 10);
+        var seat = DataInitializerFactory.seat(shopReservation);
+        var shopReservationDateTime = DataInitializerFactory.shopReservationDateTime(shopReservation);
+        var shopReservationDateTimeSeat = DataInitializerFactory.shopReservationDateTimeSeat(shopReservationDateTime, seat);
+        var reservation = DataInitializerFactory.reservation(1L, shopReservation, 2);
+
+        given(shopReservationRepository.findById(any(Long.class)))
+                .willReturn(Optional.ofNullable(shopReservation));
+        given(shopReservationDateTimeSeatRepository.findById(any(Long.class)))
+                .willReturn(Optional.ofNullable(shopReservationDateTimeSeat));
+        given(reservationRepository.save(any(Reservation.class)))
+                .willReturn(reservation);
+
+        var shopReservationDateTimeSeats = List.of(3L, 4L, 5L);
+        var personCount = 2;
+
+        var reservationCreateRequest = new ReservationCreateRequest(1L,
+                2L,
+                shopReservationDateTimeSeats,
+                "요구사항 입니다.",
+                personCount);
+
+        //when&then
+        assertThatThrownBy(() -> reservationService.createReservation(reservationCreateRequest))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("예약하려는 좌석의 수가 예약 인원 수를 초과했습니다. seats size : " + shopReservationDateTimeSeats.size() + ", person count : " + personCount);
+    }
+}

--- a/src/test/java/com/mdh/devtable/reservation/application/ReservationValidatorTest.java
+++ b/src/test/java/com/mdh/devtable/reservation/application/ReservationValidatorTest.java
@@ -1,0 +1,106 @@
+package com.mdh.devtable.reservation.application;
+
+import com.mdh.devtable.DataInitializerFactory;
+import com.mdh.devtable.reservation.infra.persistence.ShopReservationDateTimeSeatRepository;
+import com.mdh.devtable.reservation.infra.persistence.ShopReservationRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationValidatorTest {
+
+    @InjectMocks
+    private ReservationValidator reservationValidator;
+
+    @Mock
+    private ShopReservationRepository shopReservationRepository;
+
+    @Mock
+    private ShopReservationDateTimeSeatRepository shopReservationDateTimeSeatRepository;
+
+    @Test
+    @DisplayName("매장 웨이팅 정보를 반환한다.")
+    void validShopWaitingTest() {
+        //given
+        var shopId = 1L;
+        var shopReservation = DataInitializerFactory.shopReservation(shopId, 2, 10);
+
+        given(shopReservationRepository.findById(any(Long.class))).willReturn(Optional.ofNullable(shopReservation));
+
+        //when
+        var findShopReservation = reservationValidator.validShopReservation(shopId);
+
+        //then
+        verify(shopReservationRepository, times(1)).findById(any(Long.class));
+        assertThat(findShopReservation).isEqualTo(shopReservation);
+    }
+
+    @Test
+    @DisplayName("해당 매장 웨이팅 정보가 없으면 예외를 던진다.")
+    void validShopWaitingExTest() {
+        //given
+        var shopId = 1L;
+
+        given(shopReservationRepository.findById(any(Long.class))).willReturn(Optional.empty());
+
+        //when & then
+        Assertions.assertThatThrownBy(() -> reservationValidator.validShopReservation(shopId))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage("매장의 예약 정보가 없습니다. shopId " + shopId);
+    }
+
+    @Test
+    @DisplayName("예약 좌석 정보들을 반환한다.")
+    void validShopReservationDateTimeSeatTest() {
+        //given
+        var shopId = 1L;
+        var shopReservationDateTimeSeatIds = List.of(1L, 2L, 3L);
+
+        var shopReservation = DataInitializerFactory.shopReservation(shopId, 2, 10);
+
+        var seat = DataInitializerFactory.seat(shopReservation);
+        var shopReservationDateTime = DataInitializerFactory.shopReservationDateTime(shopReservation);
+
+        var shopReservationDateTimeSeat = DataInitializerFactory.shopReservationDateTimeSeat(shopReservationDateTime, seat);
+
+        given(shopReservationDateTimeSeatRepository.findById(any(Long.class))).willReturn(Optional.ofNullable(shopReservationDateTimeSeat));
+
+        //when
+        var findShopReservationDateTimeSeats = reservationValidator.validShopReservationDateTimeSeats(shopReservationDateTimeSeatIds);
+
+        //then
+        verify(shopReservationDateTimeSeatRepository, times(3)).findById(any(Long.class));
+        assertThat(findShopReservationDateTimeSeats).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("해당 예약 좌석이 없으면 예외를 던진다.")
+    void validShopReservationDateTimeSeatExTest() {
+        //given
+        var shopReservationDateTimeSeatId1 = 1L;
+        var shopReservationDateTimeSeatId2 = 1L;
+        var shopReservationDateTimeSeatIds = List.of(shopReservationDateTimeSeatId1, shopReservationDateTimeSeatId2);
+
+        given(shopReservationDateTimeSeatRepository.findById(any(Long.class))).willReturn(Optional.empty());
+
+        //when & then
+        Assertions.assertThatThrownBy(() -> reservationValidator.validShopReservationDateTimeSeats(shopReservationDateTimeSeatIds))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage("예약 좌석 정보가 없습니다. shopReservationDateTimeSeatId : " + shopReservationDateTimeSeatId1);
+    }
+}

--- a/src/test/java/com/mdh/devtable/reservation/domain/ReservationTest.java
+++ b/src/test/java/com/mdh/devtable/reservation/domain/ReservationTest.java
@@ -115,4 +115,48 @@ class ReservationTest {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("예약이 CREATED 상태에서만 상태변경이 가능합니다.");
     }
+
+    @Test
+    @DisplayName("예약 좌석의 수는 예약 인원보다 같거나 작아야 한다.")
+    void isSeatSizeUnderOrSamePersonCountTest() {
+        //given
+        var shopId = 1L;
+        var minimumCount = 2;
+        var maximumCount = 30;
+        var shopReservation = DataInitializerFactory.shopReservation(shopId, minimumCount, maximumCount);
+
+        var userId = 1L;
+        var personCount = 3;
+        var reservation = DataInitializerFactory.reservation(userId, shopReservation, personCount);
+
+        var shopReservationDateTimeSeatsSize = 3;
+
+        //when
+        boolean isUnderOrSame = reservation.isSeatsSizeUnderOrSamePersonCount(shopReservationDateTimeSeatsSize);
+
+        //then
+        assertThat(isUnderOrSame).isTrue();
+    }
+
+    @Test
+    @DisplayName("예약 좌석의 수가 예약 인원보다 크다면 false를 반환한다.")
+    void isSeatSizeUnderOrSamePersonCountFalseTest() {
+        //given
+        var shopId = 1L;
+        var minimumCount = 2;
+        var maximumCount = 30;
+        var shopReservation = DataInitializerFactory.shopReservation(shopId, minimumCount, maximumCount);
+
+        var userId = 1L;
+        var personCount = 3;
+        var reservation = DataInitializerFactory.reservation(userId, shopReservation, personCount);
+
+        var shopReservationDateTimeSeatsSize = 4;
+
+        //when
+        boolean isUnderOrSame = reservation.isSeatsSizeUnderOrSamePersonCount(shopReservationDateTimeSeatsSize);
+
+        //then
+        assertThat(isUnderOrSame).isFalse();
+    }
 }


### PR DESCRIPTION
## 🖊️ 1. Changes

- **유저 아이디, 매장 아이디, 예약 좌석 아이디, 예약 인원**을 받아 예약을 생성하고 예약 좌석들에 생성된 예약을 등록합니다.
- 매장 예약 정보와 예약 좌석에 대한 검증은 Validator 클래스로 분리하였습니다.
- 예약 좌석의 수가 에약 인원을 초과하면 예외가 발생되도록 하였습니다.

## 🖼️ 2. Screenshot

- 예약 검증 테스트
![image](https://github.com/prgrms-be-devcourse/BE-04-DevTable/assets/83766322/e0ecfa74-ae01-4c24-945a-686601061464)

- 예약 생성 테스트
![image](https://github.com/prgrms-be-devcourse/BE-04-DevTable/assets/83766322/e35db216-4dfa-4906-907a-ff097ca07b9a)

## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer

-

## ✅ 5. Plans
- [ ] - 예약에 대한 선점권 구현
- [ ] - 예약 생성 api & rest docs 작성
