### PR TITLE
[MDH-66] feat & test : 예약을 선점, 확정, 취소 기능 추가 및 테스트

### DIFF
--- a/src/main/java/com/mdh/devtable/DevTableApplication.java
+++ b/src/main/java/com/mdh/devtable/DevTableApplication.java
@@ -1,13 +1,26 @@
 package com.mdh.devtable;
 
+import com.mdh.devtable.reservation.domain.Reservation;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+import java.util.*;
 
 @SpringBootApplication
 public class DevTableApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(DevTableApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(DevTableApplication.class, args);
+    }
 
+    @Bean
+    public Set<Long> preemtiveShopReservationDateTimeSeats() {
+        return new HashSet<>();
+    }
+
+    @Bean
+    public Map<UUID, Reservation> preemptiveReservation() {
+        return new HashMap<>();
+    }
 }

--- a/src/main/java/com/mdh/devtable/reservation/application/ReservationService.java
+++ b/src/main/java/com/mdh/devtable/reservation/application/ReservationService.java
@@ -1,6 +1,8 @@
 package com.mdh.devtable.reservation.application;
 
-import com.mdh.devtable.reservation.controller.dto.ReservationCreateRequest;
+import com.mdh.devtable.reservation.controller.dto.ReservationCancelRequest;
+import com.mdh.devtable.reservation.controller.dto.ReservationPreemptiveRequest;
+import com.mdh.devtable.reservation.controller.dto.ReservationRegisterRequest;
 import com.mdh.devtable.reservation.domain.Reservation;
 import com.mdh.devtable.reservation.domain.ShopReservation;
 import com.mdh.devtable.reservation.domain.ShopReservationDateTimeSeat;
@@ -12,8 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.NoSuchElementException;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
@@ -23,17 +24,61 @@ public class ReservationService {
     private final ShopReservationDateTimeSeatRepository shopReservationDateTimeSeatRepository;
     private final ShopReservationRepository shopReservationRepository;
 
+    private final Set<Long> preemtiveShopReservationDateTimeSeats;
+
+    private final Map<UUID, Reservation> preemtiveReservations;
+
+    public UUID preemtiveReservation(ReservationPreemptiveRequest reservationPreemtiveRequest) {
+        // 선점된 좌석인지 확인한다.
+        var shopReservationDateTimeSeatIds = reservationPreemtiveRequest.shopReservationDateTimeSeatIds();
+        validPreemtiveShopReservationDateTimeSeats(shopReservationDateTimeSeatIds);
+
+        // 모든 좌석을 선점함
+        preemtiveShopReservationDateTimeSeats.addAll(reservationPreemtiveRequest.shopReservationDateTimeSeatIds());
+
+        // 예약을 만듦
+        var reservation = createReservation(reservationPreemtiveRequest);
+
+        // 만든 예약을 캐시에 저장
+        var createdReservation = preemtiveReservations.put(reservation.getReservationId(), reservation);
+
+        return createdReservation.getReservationId();
+    }
+
     @Transactional
-    public void createReservation(ReservationCreateRequest reservationCreateRequest) {
-        var shopId = reservationCreateRequest.shopId();
+    public void registerReservation(UUID reservationId, ReservationRegisterRequest reservationRegisterRequest) {
+        // 선점한 예약인지 확인
+        var shopReservationDateTimeSeatIds = reservationRegisterRequest.shopReservationDateTimeSeatIds();
+        validRegisterReservations(reservationId, shopReservationDateTimeSeatIds);
 
+        // 미리 만들었던 예약을 가져옴
+        var reservation = preemtiveReservations.get(reservationId);
+
+        // 예약 검증
+        reservation.validSeatSizeAndPersonCount(reservationRegisterRequest.totalSeatCount());
+
+        // shop reservation과 shop reservation datetime seat 영속 상태로 만듦
+        var shopId = reservationRegisterRequest.shopId();
         var shopReservation = findShopReservation(shopId);
-        var shopReservationDateTimeSeats = findShopReservationDateTimeSeats(reservationCreateRequest.shopReservationDateTimeSeatIds());
+        var shopReservationDateTimeSeats = findShopReservationDateTimeSeats(shopReservationDateTimeSeatIds);
 
-        var reservation = saveReservation(reservationCreateRequest, shopReservation);
-        reservation.validSeatSizeAndPersonCount(reservationCreateRequest.seatTotalCount());
+        // reservation 저장
+        var savedReservation = reservationRepository.save(reservation);
 
-        reservation.addShopReservationDateTimeSeats(shopReservationDateTimeSeats);
+        // 연결함
+        savedReservation.addShopReservation(shopReservation);
+        savedReservation.addShopReservationDateTimeSeats(shopReservationDateTimeSeats);
+
+        // 모두 삭제
+        removeAll(reservationId, shopReservationDateTimeSeatIds);
+    }
+
+    public void cancelPreemptiveReservation(UUID reservationId, ReservationCancelRequest reservationCancelRequest) {
+        var shopReservationDateTimeSeatIds = reservationCancelRequest.shopReservationDateTimeSeatIds();
+        validCancelReservations(reservationId, shopReservationDateTimeSeatIds);
+
+        // 선점에서 모두 삭제
+        removeAll(reservationId, shopReservationDateTimeSeatIds);
     }
 
     @Transactional
@@ -59,12 +104,8 @@ public class ReservationService {
         reservation.updateReservation(shopReservationDateTimeSeats);
     }
 
-    private Reservation saveReservation(ReservationCreateRequest reservationCreateRequest, ShopReservation shopReservation) {
-        var reservation = new Reservation(reservationCreateRequest.userId(),
-                shopReservation,
-                reservationCreateRequest.requirement(),
-                reservationCreateRequest.personCount());
-        return reservationRepository.save(reservation);
+    public Reservation createReservation(ReservationPreemptiveRequest reservationPreemptiveRequest) {
+        return new Reservation(reservationPreemptiveRequest.userId(), reservationPreemptiveRequest.requirement(), reservationPreemptiveRequest.personCount());
     }
 
     private ShopReservation findShopReservation(Long shopId) {
@@ -78,5 +119,45 @@ public class ReservationService {
             throw new NoSuchElementException("예약 좌석 정보들 중 일부가 없습니다.");
         }
         return shopReservationDateTimeSeats;
+    }
+
+    private void validPreemtiveShopReservationDateTimeSeats(List<Long> shopReservationDateTimeSeatIds) {
+        // 선점된 좌석인지 확인
+        shopReservationDateTimeSeatIds.forEach(shopReservationDateTimeSeatId -> {
+            if (preemtiveShopReservationDateTimeSeats.contains(shopReservationDateTimeSeatId)) {
+                throw new IllegalArgumentException("이미 선점된 좌석이므로 선점할 수 없습니다.");
+            }
+        });
+    }
+
+    private void validRegisterReservations(UUID reservationId, List<Long> shopReservationDateTimeSeatIds) {
+        // 선점한 예약인지 확인
+        if (!preemtiveReservations.containsKey(reservationId)) {
+            throw new IllegalArgumentException("선점된 예약이 아니므로 예약 확정할 수 없습니다.");
+        }
+        // 선점된 좌석인지 확인
+        shopReservationDateTimeSeatIds.forEach(shopReservationDateTimeSeatId -> {
+            if (!preemtiveShopReservationDateTimeSeats.contains(shopReservationDateTimeSeatId)) {
+                throw new IllegalArgumentException("선점된 좌석이 아니므로 예약 확정할 수 없습니다.");
+            }
+        });
+    }
+
+    private void validCancelReservations(UUID reservationId, List<Long> shopReservationDateTimeSeatIds) {
+        // 선점한 예약인지 확인
+        if (!preemtiveReservations.containsKey(reservationId)) {
+            throw new IllegalArgumentException("선점된 예약이 아니므로 예약 취소할 수 없습니다.");
+        }
+        // 선점된 좌석인지 확인
+        shopReservationDateTimeSeatIds.forEach(shopReservationDateTimeSeatId -> {
+            if (!preemtiveShopReservationDateTimeSeats.contains(shopReservationDateTimeSeatId)) {
+                throw new IllegalArgumentException("선점된 좌석이 아니므로 예약 취소할 수 없습니다.");
+            }
+        });
+    }
+
+    private void removeAll(UUID reservationId, List<Long> shopReservationDateTimeSeatIds) {
+        preemtiveReservations.remove(reservationId);
+        shopReservationDateTimeSeatIds.forEach(preemtiveShopReservationDateTimeSeats::remove);
     }
 }

--- a/src/main/java/com/mdh/devtable/reservation/controller/dto/ReservationCancelRequest.java
+++ b/src/main/java/com/mdh/devtable/reservation/controller/dto/ReservationCancelRequest.java
@@ -1,0 +1,8 @@
+package com.mdh.devtable.reservation.controller.dto;
+
+import java.util.List;
+
+public record ReservationCancelRequest(
+        List<Long> shopReservationDateTimeSeatIds
+) {
+}

--- a/src/main/java/com/mdh/devtable/reservation/controller/dto/ReservationPreemptiveRequest.java
+++ b/src/main/java/com/mdh/devtable/reservation/controller/dto/ReservationPreemptiveRequest.java
@@ -2,11 +2,9 @@ package com.mdh.devtable.reservation.controller.dto;
 
 import java.util.List;
 
-public record ReservationCreateRequest(
+public record ReservationPreemptiveRequest(
         Long userId,
-        Long shopId,
         List<Long> shopReservationDateTimeSeatIds,
-        int seatTotalCount,
         String requirement,
         int personCount
 ) {

--- a/src/main/java/com/mdh/devtable/reservation/controller/dto/ReservationRegisterRequest.java
+++ b/src/main/java/com/mdh/devtable/reservation/controller/dto/ReservationRegisterRequest.java
@@ -1,0 +1,10 @@
+package com.mdh.devtable.reservation.controller.dto;
+
+import java.util.List;
+
+public record ReservationRegisterRequest(
+        Long shopId,
+        List<Long> shopReservationDateTimeSeatIds,
+        int totalSeatCount
+) {
+}

--- a/src/main/java/com/mdh/devtable/reservation/domain/Reservation.java
+++ b/src/main/java/com/mdh/devtable/reservation/domain/Reservation.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 
 @Getter
@@ -42,6 +43,9 @@ public class Reservation extends BaseTimeEntity {
     @Column(name = "status", length = 15, nullable = false)
     private ReservationStatus reservationStatus;
 
+    @Transient
+    private UUID reservationId;
+
     @Builder
     public Reservation(
             Long userId,
@@ -54,7 +58,25 @@ public class Reservation extends BaseTimeEntity {
         this.shopReservation = shopReservation;
         this.requirement = requirement;
         this.personCount = personCount;
+        this.reservationId = UUID.randomUUID();
         this.reservationStatus = ReservationStatus.CREATED;
+    }
+
+    public Reservation(
+            Long userId,
+            String requirement,
+            int personCount
+    ) {
+        this.userId = userId;
+        this.requirement = requirement;
+        this.personCount = personCount;
+        this.reservationId = UUID.randomUUID();
+        this.reservationStatus = ReservationStatus.CREATED;
+    }
+
+    public void addShopReservation(ShopReservation shopReservation) {
+        shopReservation.validPersonCount(this.personCount);
+        this.shopReservation = shopReservation;
     }
 
     public void addShopReservationDateTimeSeats(List<ShopReservationDateTimeSeat> shopReservationDateTimeSeats) {

--- a/src/test/java/com/mdh/devtable/DataInitializerFactory.java
+++ b/src/test/java/com/mdh/devtable/DataInitializerFactory.java
@@ -136,6 +136,10 @@ public final class DataInitializerFactory {
                 .build();
     }
 
+    public static Reservation preemptiveReservation(Long userId, int personCount) {
+        return new Reservation(userId, "요구사항 입니다. 요구 사항은 null 일 수 있습니다.", personCount);
+    }
+
     public static Seat seat(ShopReservation shopReservation, int seatCount) {
         return new Seat(shopReservation, seatCount, SeatType.ROOM);
     }

--- a/src/test/java/com/mdh/devtable/reservation/application/ReservationServiceTest.java
+++ b/src/test/java/com/mdh/devtable/reservation/application/ReservationServiceTest.java
@@ -1,7 +1,9 @@
 package com.mdh.devtable.reservation.application;
 
 import com.mdh.devtable.DataInitializerFactory;
-import com.mdh.devtable.reservation.controller.dto.ReservationCreateRequest;
+import com.mdh.devtable.reservation.controller.dto.ReservationCancelRequest;
+import com.mdh.devtable.reservation.controller.dto.ReservationPreemptiveRequest;
+import com.mdh.devtable.reservation.controller.dto.ReservationRegisterRequest;
 import com.mdh.devtable.reservation.domain.Reservation;
 import com.mdh.devtable.reservation.domain.ReservationStatus;
 import com.mdh.devtable.reservation.infra.persistence.ReservationRepository;
@@ -19,9 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Optional;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -45,9 +45,66 @@ class ReservationServiceTest {
     @Mock
     private ShopReservationRepository shopReservationRepository;
 
+    @Mock
+    private Set<Long> preemtiveShopReservationDateTimeSeats;
+
+    @Mock
+    private Map<UUID, Reservation> preemtiveReservations;
+
     @Test
-    @DisplayName("예약을 등록한다.")
-    void createReservationTest() {
+    @DisplayName("예약을 선점한다.")
+    void preemptiveReservationTest() {
+        //given
+        var userId = 1L;
+        var shopReservationDateTimeSeatIds = List.of(1L, 2L, 3L);
+        var requirement = "요구사항입니다.";
+        var personCount = 3;
+        var reservationPreemptiveRequest = new ReservationPreemptiveRequest(userId,
+                shopReservationDateTimeSeatIds,
+                requirement,
+                personCount);
+        var reservation = DataInitializerFactory.preemptiveReservation(userId, personCount);
+
+        given(preemtiveShopReservationDateTimeSeats.contains(any(Long.class))).willReturn(false);
+        given(preemtiveShopReservationDateTimeSeats.addAll(anyList())).willReturn(true);
+        given(preemtiveReservations.put(any(UUID.class), any(Reservation.class))).willReturn(reservation);
+
+        //when
+        UUID reservationId = reservationService.preemtiveReservation(reservationPreemptiveRequest);
+
+        //then
+        verify(preemtiveShopReservationDateTimeSeats, times(3)).contains(any(Long.class));
+        verify(preemtiveShopReservationDateTimeSeats, times(1)).addAll(anyList());
+        verify(preemtiveReservations, times(1)).put(any(UUID.class), any(Reservation.class));
+
+        assertThat(reservationId).isEqualTo(reservation.getReservationId());
+    }
+
+    @Test
+    @DisplayName("좌석을 선점할 때 이미 선점된 좌석이면 예외가 발생한다.")
+    void preemptiveReservationExTest() {
+        //given
+        var userId = 1L;
+        var shopReservationDateTimeSeatIds = List.of(1L, 2L, 3L);
+        var requirement = "요구사항입니다.";
+        var personCount = 3;
+        var reservationPreemptiveRequest = new ReservationPreemptiveRequest(userId,
+                shopReservationDateTimeSeatIds,
+                requirement,
+                personCount);
+        var reservation = DataInitializerFactory.preemptiveReservation(userId, personCount);
+
+        given(preemtiveShopReservationDateTimeSeats.contains(any(Long.class))).willReturn(true);
+
+        //when
+        assertThatThrownBy(() -> reservationService.preemtiveReservation(reservationPreemptiveRequest))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미 선점된 좌석이므로 선점할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("선점한 예약을 확정한다.")
+    void registerReservationTest() {
         //given
         var shopReservation = DataInitializerFactory.shopReservation(1L, 2, 10);
 
@@ -59,43 +116,106 @@ class ReservationServiceTest {
         var shopReservationDateTimeSeat1 = DataInitializerFactory.shopReservationDateTimeSeat(shopReservationDateTime, seat);
         var shopReservationDateTimeSeat2 = DataInitializerFactory.shopReservationDateTimeSeat(shopReservationDateTime, seat);
 
-        var reservation = DataInitializerFactory.reservation(1L, shopReservation, 3);
+        var reservationRegisterRequest = new ReservationRegisterRequest(1L,
+                List.of(1L, 2L),
+                4);
+        var reservation = DataInitializerFactory.preemptiveReservation(1L, 3);
+        var reservationId = reservation.getReservationId();
+
+        given(preemtiveShopReservationDateTimeSeats.contains(any(Long.class))).willReturn(true);
+        given(preemtiveReservations.containsKey(any(UUID.class))).willReturn(true);
+        given(preemtiveReservations.get(any(UUID.class))).willReturn(reservation);
 
         given(shopReservationRepository.findById(any(Long.class))).willReturn(Optional.ofNullable(shopReservation));
         given(shopReservationDateTimeSeatRepository.findAllById(anyIterable())).willReturn(List.of(shopReservationDateTimeSeat1, shopReservationDateTimeSeat2));
+
         given(reservationRepository.save(any(Reservation.class))).willReturn(reservation);
 
-        var reservationCreateRequest = new ReservationCreateRequest(1L, 2L, List.of(3L, 4L), 4, "요구사항 입니다.", 4);
+        given(preemtiveReservations.remove(any(UUID.class))).willReturn(reservation);
+        given(preemtiveShopReservationDateTimeSeats.remove(any(Long.class))).willReturn(true);
 
         //when
-        reservationService.createReservation(reservationCreateRequest);
+        reservationService.registerReservation(reservationId, reservationRegisterRequest);
 
         //then
+        verify(preemtiveShopReservationDateTimeSeats, times(2)).contains(any(Long.class));
+        verify(preemtiveReservations, times(1)).containsKey(any(UUID.class));
+        verify(preemtiveReservations, times(1)).get(any(UUID.class));
+
         verify(shopReservationRepository, times(1)).findById(any(Long.class));
         verify(shopReservationDateTimeSeatRepository, times(1)).findAllById(anyIterable());
+
         verify(reservationRepository, times(1)).save(any(Reservation.class));
+
+        verify(preemtiveReservations, times(1)).remove(any(UUID.class));
+        verify(preemtiveShopReservationDateTimeSeats, times(2)).remove(any(Long.class));
     }
 
     @Test
-    @DisplayName("해당 매장의 예약 정보가 없다면 예외가 발생한다.")
-    void createReservationNoSuchShopReservationExTest() {
+    @DisplayName("선점된 예약이 아니라면 예약을 확정할 때 예외가 발생한다.")
+    void registerReservationNotPreemptiveReservationExTest() {
+        //given
+        var reservationRegisterRequest = new ReservationRegisterRequest(1L,
+                List.of(1L, 2L),
+                4);
+        var reservation = DataInitializerFactory.preemptiveReservation(1L, 3);
+        var reservationId = reservation.getReservationId();
+
+        given(preemtiveReservations.containsKey(any(UUID.class))).willReturn(false);
+
+        //when & then
+        assertThatThrownBy(() -> reservationService.registerReservation(reservationId, reservationRegisterRequest))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("선점된 예약이 아니므로 예약 확정할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("선점된 좌석이 아니라면 예약을 확정할 때 예외가 발생한다.")
+    void registerReservationNotPreemptiveSeatExTest() {
+        //given
+        var reservationRegisterRequest = new ReservationRegisterRequest(1L,
+                List.of(1L, 2L),
+                4);
+        var reservation = DataInitializerFactory.preemptiveReservation(1L, 3);
+        var reservationId = reservation.getReservationId();
+
+        given(preemtiveReservations.containsKey(any(UUID.class))).willReturn(true);
+        given(preemtiveShopReservationDateTimeSeats.contains(any(Long.class))).willReturn(false);
+
+        //when & then
+        assertThatThrownBy(() -> reservationService.registerReservation(reservationId, reservationRegisterRequest))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("선점된 좌석이 아니므로 예약 확정할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("해당 매장의 예약 정보가 없다면 예약을 확정할 때 예외가 발생한다.")
+    void registerReservationNotFoundShopReservationExTest() {
         //given
         var shopId = 1L;
+        var reservationRegisterRequest = new ReservationRegisterRequest(shopId,
+                List.of(1L, 2L),
+                4);
+        var reservation = DataInitializerFactory.preemptiveReservation(1L, 3);
+        var reservationId = reservation.getReservationId();
+
+        given(preemtiveShopReservationDateTimeSeats.contains(any(Long.class))).willReturn(true);
+        given(preemtiveReservations.containsKey(any(UUID.class))).willReturn(true);
+        given(preemtiveReservations.get(any(UUID.class))).willReturn(reservation);
 
         given(shopReservationRepository.findById(any(Long.class))).willReturn(Optional.empty());
 
-        var reservationCreateRequest = new ReservationCreateRequest(1L, shopId, List.of(3L, 4L, 5L), 3, "요구사항 입니다.", 3);
-
-        //when&then
-        assertThatThrownBy(() -> reservationService.createReservation(reservationCreateRequest)).isInstanceOf(NoSuchElementException.class).hasMessage("매장의 예약 정보가 없습니다. shopId " + shopId);
+        //when & then
+        assertThatThrownBy(() -> reservationService.registerReservation(reservationId, reservationRegisterRequest))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage("매장의 예약 정보가 없습니다. shopId " + shopId);
     }
 
     @Test
-    @DisplayName("예약 좌석들 중 일부가 없다면 예외가 발생한다.")
-    void ecreateReservationTest() {
+    @DisplayName("해당 예약 좌석 정보가 없다면 예약을 확정할 때 예외가 발생한다.")
+    void registerReservationNotFoundSeatsExTest() {
         //given
         var shopReservation = DataInitializerFactory.shopReservation(1L, 2, 10);
-        var shopReservationDateTimeSeatId = 3L;
 
         var seatCount = 2;
         var seat = DataInitializerFactory.seat(shopReservation, seatCount);
@@ -104,14 +224,82 @@ class ReservationServiceTest {
 
         var shopReservationDateTimeSeat = DataInitializerFactory.shopReservationDateTimeSeat(shopReservationDateTime, seat);
 
+        var reservationRegisterRequest = new ReservationRegisterRequest(1L,
+                List.of(1L, 2L),
+                4);
+        var reservation = DataInitializerFactory.preemptiveReservation(1L, 3);
+        var reservationId = reservation.getReservationId();
+
+        given(preemtiveShopReservationDateTimeSeats.contains(any(Long.class))).willReturn(true);
+        given(preemtiveReservations.containsKey(any(UUID.class))).willReturn(true);
+        given(preemtiveReservations.get(any(UUID.class))).willReturn(reservation);
 
         given(shopReservationRepository.findById(any(Long.class))).willReturn(Optional.ofNullable(shopReservation));
         given(shopReservationDateTimeSeatRepository.findAllById(anyIterable())).willReturn(List.of(shopReservationDateTimeSeat));
 
-        var reservationCreateRequest = new ReservationCreateRequest(1L, 2L, List.of(shopReservationDateTimeSeatId, 4L), 4, "요구사항 입니다.", 4);
+        //when & then
+        assertThatThrownBy(() -> reservationService.registerReservation(reservationId, reservationRegisterRequest))
+                .isInstanceOf(NoSuchElementException.class)
+                .hasMessage("예약 좌석 정보들 중 일부가 없습니다.");
+    }
 
-        //when&then
-        assertThatThrownBy(() -> reservationService.createReservation(reservationCreateRequest)).isInstanceOf(NoSuchElementException.class).hasMessage("예약 좌석 정보들 중 일부가 없습니다.");
+
+    @Test
+    @DisplayName("선점한 예약을 취소한다.")
+    void registerCancelTest() {
+        //given
+        var reservationCancelRequest = new ReservationCancelRequest(List.of(1L, 2L));
+        var reservation = DataInitializerFactory.preemptiveReservation(1L, 3);
+        var reservationId = reservation.getReservationId();
+
+        given(preemtiveShopReservationDateTimeSeats.contains(any(Long.class))).willReturn(true);
+        given(preemtiveReservations.containsKey(any(UUID.class))).willReturn(true);
+
+        given(preemtiveReservations.remove(any(UUID.class))).willReturn(reservation);
+        given(preemtiveShopReservationDateTimeSeats.remove(any(Long.class))).willReturn(true);
+
+        //when
+        reservationService.cancelPreemptiveReservation(reservationId, reservationCancelRequest);
+
+        //then
+        verify(preemtiveShopReservationDateTimeSeats, times(2)).contains(any(Long.class));
+        verify(preemtiveReservations, times(1)).containsKey(any(UUID.class));
+
+        verify(preemtiveReservations, times(1)).remove(any(UUID.class));
+        verify(preemtiveShopReservationDateTimeSeats, times(2)).remove(any(Long.class));
+    }
+
+    @Test
+    @DisplayName("선점된 예약이 아니라면 예약을 취소할 때 예외가 발생한다.")
+    void registerCancelNotPreemptiveReservationTest() {
+        //given
+        var reservationCancelRequest = new ReservationCancelRequest(List.of(1L, 2L));
+        var reservation = DataInitializerFactory.preemptiveReservation(1L, 3);
+        var reservationId = reservation.getReservationId();
+
+        given(preemtiveReservations.containsKey(any(UUID.class))).willReturn(false);
+
+        //when & then
+        assertThatThrownBy(() -> reservationService.cancelPreemptiveReservation(reservationId, reservationCancelRequest))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("선점된 예약이 아니므로 예약 취소할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("선점된 좌석이 아니라면 예약을 취소할 때 예외가 발생한다.")
+    void registerCancelNotPreemptiveSeatTest() {
+        //given
+        var reservationCancelRequest = new ReservationCancelRequest(List.of(1L, 2L));
+        var reservation = DataInitializerFactory.preemptiveReservation(1L, 3);
+        var reservationId = reservation.getReservationId();
+
+        given(preemtiveReservations.containsKey(any(UUID.class))).willReturn(true);
+        given(preemtiveShopReservationDateTimeSeats.contains(any(Long.class))).willReturn(false);
+
+        //when & then
+        assertThatThrownBy(() -> reservationService.cancelPreemptiveReservation(reservationId, reservationCancelRequest))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("선점된 좌석이 아니므로 예약 취소할 수 없습니다.");
     }
 
     @Test


### PR DESCRIPTION
## 🖊️ 1. Changes

- 예약은 다음과 같은 순으로 진행됩니다.
   - 예약 선점 -> 확정
   - 예약 선점 -> 취소
- 예약을 선점할 때는 DB의 쓰기 작업을 하지 않고 캐시에 저장한 뒤
   - preemtiveShopReservationDateTimeSeats : 선점한 좌석을 저장
   - preemtiveReservations : 선점한 예약을 저장
- 예약을 확정했을 때 캐시에서 꺼내 매장 예약, 예약 좌석을 영속화한 뒤 데이터 베이스에 저장한 예약과 연결했습니다.
- 캐시를 자바의 자료구조로 구현했습니다. 
- 캐시를 클래스로 감싼 뒤 빈으로 등록하지 않은 이유는 단순히 add, get, contains, remove 작업만 하기 때문입니다.

## 🖼️ 2. Screenshot

- 예약 서비스 테스트
![reservation service test](https://github.com/prgrms-be-devcourse/BE-04-DevTable/assets/83766322/88859142-122c-435f-ab8f-357a3f26297b)


## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer

- 

## ✅ 5. Plans
- [ ] - 예약 등록 api, rest docs 작성
- [ ] - 리뷰 반영 
- [x] - pr 충돌 해결