### PR TITLE
@DataJpaTest 사용 시 Common 모듈에 있는 Repository를 주입받지 못하는 오류 해결

### DIFF
--- a/owner/src/test/java/com/mdh/owner/JpaTestConfig.java
+++ b/owner/src/test/java/com/mdh/owner/JpaTestConfig.java
@@ -1,0 +1,11 @@
+package com.mdh.owner;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.context.ActiveProfiles;
+
+@TestConfiguration
+@ActiveProfiles("test")
+@ComponentScan("com.mdh.common")
+public class JpaTestConfig {
+}

--- a/owner/src/test/java/com/mdh/owner/reservation/read/infra/persistence/OwnerReservationReadRepositoryTest.java
+++ b/owner/src/test/java/com/mdh/owner/reservation/read/infra/persistence/OwnerReservationReadRepositoryTest.java
@@ -1,21 +1,25 @@
 package com.mdh.owner.reservation.read.infra.persistence;
 
+import com.mdh.common.global.config.JpaConfig;
 import com.mdh.common.reservation.ReservationStatus;
 import com.mdh.common.reservation.persistence.*;
 import com.mdh.common.shop.persistence.RegionRepository;
 import com.mdh.common.shop.persistence.ShopRepository;
 import com.mdh.common.user.persistence.UserRepository;
 import com.mdh.owner.DataInitializerFactory;
+import com.mdh.owner.JpaTestConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Profile;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
-@Profile("test")
+@DataJpaTest
+@Import({JpaConfig.class, JpaTestConfig.class})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class OwnerReservationReadRepositoryTest {
 
     @Autowired

--- a/owner/src/test/java/com/mdh/owner/waiting/infra/persistence/OwnerWaitingRepositoryTest.java
+++ b/owner/src/test/java/com/mdh/owner/waiting/infra/persistence/OwnerWaitingRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.mdh.owner.waiting.infra.persistence;
 
+import com.mdh.common.global.config.JpaConfig;
 import com.mdh.common.shop.persistence.RegionRepository;
 import com.mdh.common.shop.persistence.ShopRepository;
 import com.mdh.common.user.persistence.UserRepository;
@@ -8,16 +9,19 @@ import com.mdh.common.waiting.domain.WaitingStatus;
 import com.mdh.common.waiting.persistence.ShopWaitingRepository;
 import com.mdh.common.waiting.persistence.WaitingRepository;
 import com.mdh.owner.DataInitializerFactory;
+import com.mdh.owner.JpaTestConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
-@ActiveProfiles("test")
+@DataJpaTest
+@Import({JpaConfig.class, JpaTestConfig.class})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class OwnerWaitingRepositoryTest {
 
     @Autowired


### PR DESCRIPTION
## 🖊️ 1. Changes

- @DataJpaTest를 하위 모듈에서 사용 할 때 상위 모듈에 있는 Repository가 주입받지 못하여 @ComponentScan을 추가하여 해결하였습니다.
- 공통된 설정이기 때문에 TestConfig를 만들어 재사용성을 높였습니다.

## 🖼️ 2. Screenshot

-

## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer

- `@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)` 이것도 빼고 싶었으나 적용이 안되네요

## ✅ 5. Plans

