### PR TITLE
[MDH-189] QueryDsl 기능 추가

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -3,8 +3,29 @@ dependencies {
     api 'org.springframework.boot:spring-boot-starter-data-redis'
     api 'com.h2database:h2'
     api 'com.mysql:mysql-connector-j'
+
+    // query-dsl 추가 spring-boot 3.0, spring 6
+    api 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// === QueryDsl 빌드 옵션  ===
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+    main.java.srcDirs += [querydslDir]
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+clean.doLast {
+    file(querydslDir).deleteDir()
 }

--- a/common/src/main/java/com/mdh/common/user/persistence/UserCustomRepository.java
+++ b/common/src/main/java/com/mdh/common/user/persistence/UserCustomRepository.java
@@ -1,0 +1,11 @@
+package com.mdh.common.user.persistence;
+
+import com.mdh.common.user.domain.Role;
+import com.mdh.common.user.domain.User;
+
+import java.util.List;
+
+public interface UserCustomRepository {
+
+    List<User> findByRole(Role role);
+}

--- a/common/src/main/java/com/mdh/common/user/persistence/UserRepository.java
+++ b/common/src/main/java/com/mdh/common/user/persistence/UserRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserCustomRepository {
 
     Optional<User> findByEmail(String email);
 }

--- a/user/src/main/java/com/mdh/user/user/infra/UserCustomRepositoryImpl.java
+++ b/user/src/main/java/com/mdh/user/user/infra/UserCustomRepositoryImpl.java
@@ -1,0 +1,2 @@
+package com.mdh.user.user.infra;public class UserCustomRepositoryImpl {
+}

--- a/user/src/main/java/com/mdh/user/user/infra/UserCustomRepositoryImpl.java
+++ b/user/src/main/java/com/mdh/user/user/infra/UserCustomRepositoryImpl.java
@@ -1,2 +1,26 @@
-package com.mdh.user.user.infra;public class UserCustomRepositoryImpl {
+package com.mdh.user.user.infra;
+
+import com.mdh.common.user.domain.Role;
+import com.mdh.common.user.domain.User;
+import com.mdh.common.user.persistence.UserCustomRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.mdh.common.user.domain.QUser.user;
+
+@RequiredArgsConstructor
+public class UserCustomRepositoryImpl implements UserCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<User> findByRole(Role role) {
+        return jpaQueryFactory
+                .select(user)
+                .from(user)
+                .where(user.role.eq(role))
+                .fetch();
+    }
 }

--- a/user/src/test/java/com/mdh/user/QueryDslTest.java
+++ b/user/src/test/java/com/mdh/user/QueryDslTest.java
@@ -1,0 +1,28 @@
+package com.mdh.user;
+
+import com.mdh.common.user.domain.Role;
+import com.mdh.common.user.persistence.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class QueryDslTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    void findUserByRoleTest() {
+        //given
+        var guest = DataInitializerFactory.guest();
+        userRepository.save(guest);
+
+        //when
+        var findUsers = userRepository.findByRole(Role.GUEST);
+
+        //then
+        Assertions.assertThat(findUsers).hasSize(1);
+    }
+}


### PR DESCRIPTION
## 🖊️ 1. Changes
- querydsl을 스프링부트 3.0 스프링 6에 맞춰서 설정하였습니다.
- 하위 모듈에 두지 않고 상위 모듈에 두어 common의 도메인과 위치를 맞추어 QDomain을 생성되도록 하였습니다.

## 🖼️ 2. Screenshot

-

## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer
- Repository를 하위 모듈에 두게 되면 Service 로직에서 두 개의 인터페이스를 의존 주입 하는 현상이 발생합니다. 이를 개선하기 위해 common영역에 custom 인터페이스를 두었습니다. 하지만 이를 개선하는 과정에서 customRepository가 presentation으로부터 전달받는 dto를 알고 있어야하는데 상위 모듈은 하위 모듈에 있는 presentation의 dto를 모르기 때문에 하위 모듈에서 해당 객체를 풀어서 상위 모듈로 전달하도록 할 예정입니다.

## ✅ 5. Plans
- [x] - querydsl을 이용한 user test 작성
