### PR TITLE
[MDH-179] 애플리케이션 모니터링 기능 추가

### DIFF
--- a/common/src/main/java/com/mdh/common/global/config/MonitoringConfig.java
+++ b/common/src/main/java/com/mdh/common/global/config/MonitoringConfig.java
@@ -1,0 +1,21 @@
+package com.mdh.common.global.config;
+
+import io.micrometer.core.aop.CountedAspect;
+import io.micrometer.core.aop.TimedAspect;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MonitoringConfig {
+
+    @Bean
+    public CountedAspect countedAspect(MeterRegistry meterRegistry) {
+        return new CountedAspect(meterRegistry);
+    }
+
+    @Bean
+    public TimedAspect timedAspect(MeterRegistry meterRegistry) {
+        return new TimedAspect(meterRegistry);
+    }
+}

--- a/common/src/main/java/com/mdh/common/global/config/MonitoringConfig.java
+++ b/common/src/main/java/com/mdh/common/global/config/MonitoringConfig.java
@@ -5,7 +5,9 @@ import io.micrometer.core.aop.TimedAspect;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
+@Profile({"default", "dev"})
 @Configuration
 public class MonitoringConfig {
 

--- a/common/src/main/java/com/mdh/common/shop/persistence/ShopRepositoryImpl.java
+++ b/common/src/main/java/com/mdh/common/shop/persistence/ShopRepositoryImpl.java
@@ -250,7 +250,8 @@ public class ShopRepositoryImpl implements ShopRepositoryCustom {
     }
 
     private OrderSpecifier<?> getOrderSpecifier(List<String> sorts) {
-        if (sorts.get(0).equals(PRICE_ASC.getSortParam())) {
+
+        if (!sorts.isEmpty() && sorts.get(0).equals(PRICE_ASC.getSortParam())) {
             return shop.shopPrice.shopMinPrice.asc();
         }
 

--- a/owner/src/main/java/com/mdh/owner/global/security/config/SecurityConfig.java
+++ b/owner/src/main/java/com/mdh/owner/global/security/config/SecurityConfig.java
@@ -42,7 +42,11 @@ public class SecurityConfig {
                 .cors(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests((authorize) -> authorize
-                        .requestMatchers(antMatcher("/api/v1/owner"), antMatcher("/hello"), antMatcher("/restdocs"))
+                        .requestMatchers(
+                                antMatcher("/api/v1/owner"),
+                                antMatcher("/hello"),
+                                antMatcher("/restdocs"),
+                                antMatcher("/actuator/**"))
                         .permitAll()
                         .anyRequest()
                         .hasRole("OWNER"))

--- a/owner/src/main/java/com/mdh/owner/menu/presentation/MenuController.java
+++ b/owner/src/main/java/com/mdh/owner/menu/presentation/MenuController.java
@@ -20,6 +20,7 @@ public class MenuController {
 
     private final MenuService menuService;
 
+    // TODO Location header로 변경
     @PostMapping("/api/owner/v1/categories/{categoryId}/menus")
     public ResponseEntity<ApiResponse<Void>> createMenu(@PathVariable("categoryId") Long categoryId, @Valid @RequestBody MenuCreateRequest request) {
         var menuId = menuService.createMenu(categoryId, request);
@@ -34,6 +35,7 @@ public class MenuController {
         return ResponseEntity.ok(ApiResponse.ok(null));
     }
 
+    // TODO Location header로 변경
     @PostMapping("/api/owner/v1/shops/{shopId}/categories")
     public ResponseEntity<ApiResponse<Void>> createMenuCategory(@PathVariable("shopId") Long shopId, @Valid @RequestBody MenuCategoryCreateRequest request) {
         var menuCategoryId = menuService.createMenuCategory(shopId, request);

--- a/owner/src/main/java/com/mdh/owner/reservation/write/application/OwnerReservationService.java
+++ b/owner/src/main/java/com/mdh/owner/reservation/write/application/OwnerReservationService.java
@@ -57,6 +57,7 @@ public class OwnerReservationService {
         reservation.updateReservationStatus(ReservationStatus.CANCEL);
     }
 
+    @Counted("owner.reservation.visit")
     @Transactional
     public void markReservationAsVisitedByOwner(Long reservationId) {
         var reservation = ownerReservationRepository.findReservationById(reservationId).orElseThrow(() -> new NoSuchElementException("해당 ID의 예약 정보가 없습니다.: " + reservationId));

--- a/owner/src/main/java/com/mdh/owner/reservation/write/application/OwnerReservationService.java
+++ b/owner/src/main/java/com/mdh/owner/reservation/write/application/OwnerReservationService.java
@@ -8,6 +8,7 @@ import com.mdh.owner.reservation.write.infra.persistence.OwnerReservationReposit
 import com.mdh.owner.reservation.write.presentation.dto.SeatCreateRequest;
 import com.mdh.owner.reservation.write.presentation.dto.ShopReservationCreateRequest;
 import com.mdh.owner.reservation.write.presentation.dto.ShopReservationDateTimeCreateRequest;
+import io.micrometer.core.annotation.Counted;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,6 +50,7 @@ public class OwnerReservationService {
         return shopReservationDateTimeId;
     }
 
+    @Counted("owner.reservation.cancel")
     @Transactional
     public void cancelReservationByOwner(Long reservationId) {
         var reservation = ownerReservationRepository.findReservationById(reservationId).orElseThrow(() -> new NoSuchElementException("해당 ID의 예약 정보가 없습니다.: " + reservationId));
@@ -61,6 +63,7 @@ public class OwnerReservationService {
         reservation.updateReservationStatus(ReservationStatus.VISITED);
     }
 
+    @Counted("owner.reservation.noShow")
     @Transactional
     public void markReservationAsNoShowByOwner(Long reservationId) {
         var reservation = ownerReservationRepository.findReservationById(reservationId).orElseThrow(() -> new NoSuchElementException("해당 ID의 예약 정보가 없습니다.: " + reservationId));

--- a/owner/src/main/java/com/mdh/owner/waiting/application/OwnerWaitingService.java
+++ b/owner/src/main/java/com/mdh/owner/waiting/application/OwnerWaitingService.java
@@ -1,18 +1,21 @@
 package com.mdh.owner.waiting.application;
 
 import com.mdh.common.waiting.domain.WaitingStatus;
-import com.mdh.owner.waiting.infra.persistence.OwnerWaitingRepository;
 import com.mdh.common.waiting.persistence.dto.WaitingInfoResponseForOwner;
+import com.mdh.owner.waiting.infra.persistence.OwnerWaitingRepository;
 import com.mdh.owner.waiting.presentation.dto.OwnerShopWaitingStatusChangeRequest;
 import com.mdh.owner.waiting.presentation.dto.OwnerUpdateShopWaitingInfoRequest;
 import com.mdh.owner.waiting.presentation.dto.OwnerWaitingStatusChangeRequest;
+import io.micrometer.core.annotation.Counted;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.NoSuchElementException;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class OwnerWaitingService {
@@ -26,11 +29,14 @@ public class OwnerWaitingService {
         shopWaiting.changeShopWaitingStatus(request.shopWaitingStatus());
     }
 
+    @Counted("owner.waiting.change")
     @Transactional
     public void changeWaitingStatus(Long waitingId, OwnerWaitingStatusChangeRequest request) {
         var waiting = ownerWaitingRepository.findWaitingByWaitingId(waitingId)
                 .orElseThrow(() -> new NoSuchElementException("웨이팅 조회 결과가 없습니다."));
+
         waiting.changeWaitingStatus(request.waitingStatus());
+        log.info("웨이팅의 상태를 {}로 변경하였습니다.", request.waitingStatus().name());
     }
 
     @Transactional(readOnly = true)

--- a/owner/src/main/java/com/mdh/owner/waiting/presentation/controller/OwnerWaitingController.java
+++ b/owner/src/main/java/com/mdh/owner/waiting/presentation/controller/OwnerWaitingController.java
@@ -1,9 +1,9 @@
 package com.mdh.owner.waiting.presentation.controller;
 
-import com.mdh.owner.global.ApiResponse;
-import com.mdh.owner.waiting.application.OwnerWaitingService;
 import com.mdh.common.waiting.domain.WaitingStatus;
 import com.mdh.common.waiting.persistence.dto.WaitingInfoResponseForOwner;
+import com.mdh.owner.global.ApiResponse;
+import com.mdh.owner.waiting.application.OwnerWaitingService;
 import com.mdh.owner.waiting.presentation.dto.OwnerShopWaitingStatusChangeRequest;
 import com.mdh.owner.waiting.presentation.dto.OwnerUpdateShopWaitingInfoRequest;
 import com.mdh.owner.waiting.presentation.dto.OwnerWaitingStatusChangeRequest;
@@ -22,6 +22,7 @@ public class OwnerWaitingController {
 
     private final OwnerWaitingService ownerWaitingService;
 
+    // TODO Method 명 변경
     @PatchMapping("/shops/{shopId}")
     public ResponseEntity<ApiResponse<Void>> changShopWaitingStatus(@RequestBody OwnerShopWaitingStatusChangeRequest request, @PathVariable("shopId") Long shopId) {
         ownerWaitingService.changeShopWaitingStatus(shopId, request);

--- a/user/src/main/java/com/mdh/user/global/security/config/SecurityConfig.java
+++ b/user/src/main/java/com/mdh/user/global/security/config/SecurityConfig.java
@@ -45,7 +45,8 @@ public class SecurityConfig {
                         .requestMatchers(antMatcher("/hello"),
                                 antMatcher("/restdocs"),
                                 antMatcher("/api/customer/v1/shops"),
-                                antMatcher("/api/v1/customers"))
+                                antMatcher("/api/v1/customers"),
+                                antMatcher("/actuator/**"))
                         .permitAll()
                         .anyRequest()
                         .hasRole("GUEST"))

--- a/user/src/main/java/com/mdh/user/reservation/application/ReservationService.java
+++ b/user/src/main/java/com/mdh/user/reservation/application/ReservationService.java
@@ -37,10 +37,10 @@ public class ReservationService {
 
     private final ApplicationEventPublisher eventPublisher;
 
-    public UUID preemtiveReservation(Long userId, ReservationPreemptiveRequest reservationPreemptiveRequest) {
+    public UUID preemptiveReservation(Long userId, ReservationPreemptiveRequest reservationPreemptiveRequest) {
         // 선점된 좌석인지 확인한다.
         var shopReservationDateTimeSeatIds = reservationPreemptiveRequest.shopReservationDateTimeSeatIds();
-        validPreemtiveShopReservationDateTimeSeats(shopReservationDateTimeSeatIds);
+        validPreemptiveShopReservationDateTimeSeats(shopReservationDateTimeSeatIds);
 
         // 모든 좌석을 선점함
         preemptiveShopReservationDateTimeSeats.addAll(reservationPreemptiveRequest.shopReservationDateTimeSeatIds());

--- a/user/src/main/java/com/mdh/user/reservation/application/ReservationService.java
+++ b/user/src/main/java/com/mdh/user/reservation/application/ReservationService.java
@@ -6,15 +6,16 @@ import com.mdh.common.reservation.domain.ShopReservation;
 import com.mdh.common.reservation.domain.ShopReservationDateTimeSeat;
 import com.mdh.common.reservation.domain.event.ReservationCanceledEvent;
 import com.mdh.common.reservation.domain.event.ReservationCreatedEvent;
-import com.mdh.user.reservation.application.dto.ReservationResponse;
-import com.mdh.user.reservation.application.dto.ReservationResponses;
 import com.mdh.common.reservation.persistence.ReservationRepository;
 import com.mdh.common.reservation.persistence.ShopReservationDateTimeSeatRepository;
 import com.mdh.common.reservation.persistence.ShopReservationRepository;
+import com.mdh.user.reservation.application.dto.ReservationResponse;
+import com.mdh.user.reservation.application.dto.ReservationResponses;
 import com.mdh.user.reservation.presentation.dto.ReservationCancelRequest;
 import com.mdh.user.reservation.presentation.dto.ReservationPreemptiveRequest;
 import com.mdh.user.reservation.presentation.dto.ReservationRegisterRequest;
 import com.mdh.user.reservation.presentation.dto.ReservationUpdateRequest;
+import io.micrometer.core.annotation.Counted;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -59,6 +60,7 @@ public class ReservationService {
         return new Reservation(userId, reservationPreemptiveRequest.requirement(), reservationPreemptiveRequest.personCount());
     }
 
+    @Counted("user.reservation.register")
     @Transactional
     public Long registerReservation(UUID reservationId, ReservationRegisterRequest reservationRegisterRequest) {
         // 선점한 예약인지 확인
@@ -108,6 +110,7 @@ public class ReservationService {
         return "성공적으로 선점된 예약을 취소했습니다.";
     }
 
+    @Counted("user.reservation.cancel")
     @Transactional
     public String cancelReservation(Long reservationId) {
         var reservation = reservationRepository.findById(reservationId)
@@ -146,7 +149,7 @@ public class ReservationService {
         return new ReservationResponses(reservationResponses);
     }
 
-    private void validPreemtiveShopReservationDateTimeSeats(List<Long> shopReservationDateTimeSeatIds) {
+    private void validPreemptiveShopReservationDateTimeSeats(List<Long> shopReservationDateTimeSeatIds) {
         // 선점된 좌석인지 확인
         shopReservationDateTimeSeatIds.forEach(shopReservationDateTimeSeatId -> {
             if (preemptiveShopReservationDateTimeSeats.contains(shopReservationDateTimeSeatId)) {

--- a/user/src/main/java/com/mdh/user/reservation/infra/eventbus/SendAlarmWithReservationCanceledEventHandler.java
+++ b/user/src/main/java/com/mdh/user/reservation/infra/eventbus/SendAlarmWithReservationCanceledEventHandler.java
@@ -3,6 +3,7 @@ package com.mdh.user.reservation.infra.eventbus;
 import com.mdh.common.reservation.domain.event.ReservationCanceledEvent;
 import com.mdh.common.reservation.persistence.ReservationRepository;
 import com.mdh.user.global.message.AlarmMessage;
+import io.micrometer.core.annotation.Counted;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -24,6 +25,7 @@ public class SendAlarmWithReservationCanceledEventHandler {
     private final StringRedisTemplate redisTemplate;
     private final ReservationRepository reservationRepository;
 
+    @Counted("alarm.user.reservation.cancel")
     @Async
     @Transactional(readOnly = true)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)

--- a/user/src/main/java/com/mdh/user/reservation/infra/eventbus/SendAlarmWithReservationCreatedEventHandler.java
+++ b/user/src/main/java/com/mdh/user/reservation/infra/eventbus/SendAlarmWithReservationCreatedEventHandler.java
@@ -3,6 +3,7 @@ package com.mdh.user.reservation.infra.eventbus;
 import com.mdh.common.reservation.domain.event.ReservationCreatedEvent;
 import com.mdh.common.reservation.persistence.ReservationRepository;
 import com.mdh.user.global.message.AlarmMessage;
+import io.micrometer.core.annotation.Counted;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -24,6 +25,7 @@ public class SendAlarmWithReservationCreatedEventHandler {
     private final StringRedisTemplate redisTemplate;
     private final ReservationRepository reservationRepository;
 
+    @Counted("alarm.user.reservation.register")
     @Async
     @Transactional(readOnly = true)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
@@ -36,7 +38,7 @@ public class SendAlarmWithReservationCreatedEventHandler {
 
         redisTemplate.convertAndSend(topic,
                 new AlarmMessage(String.valueOf(reservationAlarmInfo.userId()),
-                reservationAlarmInfo.shopName(),
-                reservationAlarmInfo.toString()));
+                        reservationAlarmInfo.shopName(),
+                        reservationAlarmInfo.toString()));
     }
 }

--- a/user/src/main/java/com/mdh/user/reservation/presentation/controller/ReservationController.java
+++ b/user/src/main/java/com/mdh/user/reservation/presentation/controller/ReservationController.java
@@ -10,6 +10,7 @@ import com.mdh.user.reservation.presentation.dto.ReservationCancelRequest;
 import com.mdh.user.reservation.presentation.dto.ReservationPreemptiveRequest;
 import com.mdh.user.reservation.presentation.dto.ReservationRegisterRequest;
 import com.mdh.user.reservation.presentation.dto.ReservationUpdateRequest;
+import io.micrometer.core.annotation.Timed;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -63,6 +64,7 @@ public class ReservationController {
         return new ResponseEntity<>(ApiResponse.ok(null), HttpStatus.OK);
     }
 
+    @Timed("user.reservation.findAll")
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<ReservationResponses>> findReservations(
             @CurrentUser UserInfo userInfo,

--- a/user/src/main/java/com/mdh/user/reservation/presentation/controller/ReservationController.java
+++ b/user/src/main/java/com/mdh/user/reservation/presentation/controller/ReservationController.java
@@ -1,7 +1,7 @@
 package com.mdh.user.reservation.presentation.controller;
 
-import com.mdh.user.global.ApiResponse;
 import com.mdh.common.reservation.domain.ReservationStatus;
+import com.mdh.user.global.ApiResponse;
 import com.mdh.user.global.security.session.CurrentUser;
 import com.mdh.user.global.security.session.UserInfo;
 import com.mdh.user.reservation.application.ReservationService;
@@ -28,7 +28,7 @@ public class ReservationController {
 
     @PostMapping("/preemption")
     public ResponseEntity<ApiResponse<UUID>> preemptReservation(@RequestBody @Valid ReservationPreemptiveRequest reservationPreemptiveRequest, @CurrentUser UserInfo userInfo) {
-        UUID reservationId = reservationService.preemtiveReservation(userInfo. userId(),reservationPreemptiveRequest);
+        UUID reservationId = reservationService.preemptiveReservation(userInfo.userId(), reservationPreemptiveRequest);
         return ResponseEntity.ok(ApiResponse.ok(reservationId));
     }
 

--- a/user/src/main/java/com/mdh/user/shop/presentation/ShopController.java
+++ b/user/src/main/java/com/mdh/user/shop/presentation/ShopController.java
@@ -6,6 +6,7 @@ import com.mdh.user.shop.application.dto.ReservationShopSearchResponse;
 import com.mdh.user.shop.application.dto.ShopDetailInfoResponse;
 import com.mdh.user.shop.application.dto.ShopResponses;
 import com.mdh.user.shop.presentation.dto.ReservationShopSearchRequest;
+import io.micrometer.core.annotation.Timed;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -24,6 +25,7 @@ public class ShopController {
 
     private final ShopService shopService;
 
+    @Timed("user.shop.waiting.findByDynamicCond")
     @GetMapping("/waitings")
     public ResponseEntity<ApiResponse<ShopResponses>> findByConditionWithWaiting(
             @RequestParam MultiValueMap<String, String> multiParams,
@@ -33,6 +35,7 @@ public class ShopController {
         return new ResponseEntity<>(ApiResponse.ok(result), HttpStatus.OK);
     }
 
+    @Timed("user.shop.reservation.findByDynamicCond")
     @GetMapping("/reservations")
     public ResponseEntity<ApiResponse<ReservationShopSearchResponse>> searchReservationShops(
             @PageableDefault(sort = "createdDate", direction = Sort.Direction.ASC) Pageable pageable,

--- a/user/src/main/java/com/mdh/user/waiting/infra/eventbus/SendAlarmWithWaitingCanceledEventHandler.java
+++ b/user/src/main/java/com/mdh/user/waiting/infra/eventbus/SendAlarmWithWaitingCanceledEventHandler.java
@@ -27,7 +27,7 @@ public class SendAlarmWithWaitingCanceledEventHandler {
     private final StringRedisTemplate redisTemplate;
     private final WaitingRepository waitingRepository;
 
-    @Counted("alarm.user.waiting.register")
+    @Counted("alarm.user.waiting.cancel")
     @Async
     @Transactional(readOnly = true)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)

--- a/user/src/main/java/com/mdh/user/waiting/infra/eventbus/SendAlarmWithWaitingCanceledEventHandler.java
+++ b/user/src/main/java/com/mdh/user/waiting/infra/eventbus/SendAlarmWithWaitingCanceledEventHandler.java
@@ -3,6 +3,7 @@ package com.mdh.user.waiting.infra.eventbus;
 import com.mdh.common.waiting.domain.event.WaitingCanceledEvent;
 import com.mdh.common.waiting.persistence.WaitingRepository;
 import com.mdh.user.global.message.AlarmMessage;
+import io.micrometer.core.annotation.Counted;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -26,6 +27,7 @@ public class SendAlarmWithWaitingCanceledEventHandler {
     private final StringRedisTemplate redisTemplate;
     private final WaitingRepository waitingRepository;
 
+    @Counted("alarm.user.waiting.register")
     @Async
     @Transactional(readOnly = true)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)

--- a/user/src/main/java/com/mdh/user/waiting/infra/eventbus/SendAlarmWithWaitingCreatedEventHandler.java
+++ b/user/src/main/java/com/mdh/user/waiting/infra/eventbus/SendAlarmWithWaitingCreatedEventHandler.java
@@ -25,7 +25,7 @@ public class SendAlarmWithWaitingCreatedEventHandler {
     private final StringRedisTemplate redisTemplate;
     private final WaitingRepository waitingRepository;
 
-    @Counted("alarm.user.waiting.cancel")
+    @Counted("alarm.user.waiting.register")
     @Async
     @Transactional(readOnly = true)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)

--- a/user/src/main/java/com/mdh/user/waiting/infra/eventbus/SendAlarmWithWaitingCreatedEventHandler.java
+++ b/user/src/main/java/com/mdh/user/waiting/infra/eventbus/SendAlarmWithWaitingCreatedEventHandler.java
@@ -1,8 +1,9 @@
 package com.mdh.user.waiting.infra.eventbus;
 
+import com.mdh.common.waiting.domain.event.WaitingCreatedEvent;
 import com.mdh.common.waiting.persistence.WaitingRepository;
 import com.mdh.user.global.message.AlarmMessage;
-import com.mdh.common.waiting.domain.event.WaitingCreatedEvent;
+import io.micrometer.core.annotation.Counted;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -24,6 +25,7 @@ public class SendAlarmWithWaitingCreatedEventHandler {
     private final StringRedisTemplate redisTemplate;
     private final WaitingRepository waitingRepository;
 
+    @Counted("alarm.user.waiting.cancel")
     @Async
     @Transactional(readOnly = true)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)

--- a/user/src/main/java/com/mdh/user/waiting/presentation/UserWaitingController.java
+++ b/user/src/main/java/com/mdh/user/waiting/presentation/UserWaitingController.java
@@ -32,6 +32,7 @@ public class UserWaitingController {
         return ResponseEntity.ok(ApiResponse.ok(findUserWaitings));
     }
 
+    //TODO Location Header 로 변경
     @PostMapping("/shops/{shopId}")
     public ResponseEntity<ApiResponse<URI>> createWaiting(@RequestBody @Valid WaitingCreateRequest waitingCreateRequest, @CurrentUser UserInfo userInfo, @PathVariable("shopId") Long shopId) {
         Long waitingId = waitingService.createWaiting(userInfo.userId(), shopId, waitingCreateRequest);

--- a/user/src/main/java/com/mdh/user/waiting/presentation/UserWaitingController.java
+++ b/user/src/main/java/com/mdh/user/waiting/presentation/UserWaitingController.java
@@ -7,8 +7,8 @@ import com.mdh.user.global.security.session.UserInfo;
 import com.mdh.user.waiting.application.WaitingService;
 import com.mdh.user.waiting.application.dto.UserWaitingResponse;
 import com.mdh.user.waiting.application.dto.WaitingDetailsResponse;
-import com.mdh.user.waiting.presentation.dto.MyWaitingsRequest;
 import com.mdh.user.waiting.presentation.dto.WaitingCreateRequest;
+import io.micrometer.core.annotation.Timed;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -25,6 +25,7 @@ public class UserWaitingController {
 
     private final WaitingService waitingService;
 
+    @Timed("user.waiting.findAllByStatus")
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<List<UserWaitingResponse>>> findWaitingsByUserIdAndStatus(@RequestParam("status") WaitingStatus status, @CurrentUser UserInfo userInfo) {
         var findUserWaitings = waitingService.findAllByUserIdAndStatus(userInfo.userId(), status);

--- a/user/src/test/java/com/mdh/user/reservation/application/ReservationServiceTest.java
+++ b/user/src/test/java/com/mdh/user/reservation/application/ReservationServiceTest.java
@@ -1,13 +1,13 @@
 package com.mdh.user.reservation.application;
 
-import com.mdh.common.reservation.domain.event.ReservationCanceledEvent;
-import com.mdh.common.reservation.domain.event.ReservationCreatedEvent;
-import com.mdh.user.DataInitializerFactory;
 import com.mdh.common.reservation.domain.Reservation;
 import com.mdh.common.reservation.domain.ReservationStatus;
+import com.mdh.common.reservation.domain.event.ReservationCanceledEvent;
+import com.mdh.common.reservation.domain.event.ReservationCreatedEvent;
 import com.mdh.common.reservation.persistence.ReservationRepository;
 import com.mdh.common.reservation.persistence.ShopReservationDateTimeSeatRepository;
 import com.mdh.common.reservation.persistence.ShopReservationRepository;
+import com.mdh.user.DataInitializerFactory;
 import com.mdh.user.reservation.presentation.dto.ReservationCancelRequest;
 import com.mdh.user.reservation.presentation.dto.ReservationPreemptiveRequest;
 import com.mdh.user.reservation.presentation.dto.ReservationRegisterRequest;
@@ -76,7 +76,7 @@ class ReservationServiceTest {
 
 
         //when
-        UUID reservationId = reservationService.preemtiveReservation(userId, reservationPreemptiveRequest);
+        UUID reservationId = reservationService.preemptiveReservation(userId, reservationPreemptiveRequest);
 
         //then
         verify(preemtiveShopReservationDateTimeSeats, times(3)).contains(any(Long.class));
@@ -102,7 +102,7 @@ class ReservationServiceTest {
         given(preemtiveShopReservationDateTimeSeats.contains(any(Long.class))).willReturn(true);
 
         //when
-        assertThatThrownBy(() -> reservationService.preemtiveReservation(userId, reservationPreemptiveRequest))
+        assertThatThrownBy(() -> reservationService.preemptiveReservation(userId, reservationPreemptiveRequest))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("이미 선점된 좌석이므로 선점할 수 없습니다.");
     }

--- a/user/src/test/java/com/mdh/user/reservation/presentation/controller/ReservationControllerTest.java
+++ b/user/src/test/java/com/mdh/user/reservation/presentation/controller/ReservationControllerTest.java
@@ -1,16 +1,16 @@
 package com.mdh.user.reservation.presentation.controller;
 
-import com.mdh.user.RestDocsSupport;
 import com.mdh.common.reservation.domain.ReservationStatus;
+import com.mdh.common.reservation.persistence.dto.ReservationQueryDto;
+import com.mdh.common.shop.domain.ShopType;
+import com.mdh.user.RestDocsSupport;
 import com.mdh.user.reservation.application.ReservationService;
 import com.mdh.user.reservation.application.dto.ReservationResponse;
 import com.mdh.user.reservation.application.dto.ReservationResponses;
-import com.mdh.common.reservation.persistence.dto.ReservationQueryDto;
 import com.mdh.user.reservation.presentation.dto.ReservationCancelRequest;
 import com.mdh.user.reservation.presentation.dto.ReservationPreemptiveRequest;
 import com.mdh.user.reservation.presentation.dto.ReservationRegisterRequest;
 import com.mdh.user.reservation.presentation.dto.ReservationUpdateRequest;
-import com.mdh.common.shop.domain.ShopType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -57,7 +57,7 @@ class ReservationControllerTest extends RestDocsSupport {
         var reservationId = UUID.randomUUID();
         var request = new ReservationPreemptiveRequest(List.of(3L, 4L), "요구사항 입니다", 4);
         var userId = 1L;
-        given(reservationService.preemtiveReservation(any(), any(ReservationPreemptiveRequest.class))).willReturn(reservationId);
+        given(reservationService.preemptiveReservation(any(), any(ReservationPreemptiveRequest.class))).willReturn(reservationId);
 
         //when & then
         mockMvc.perform(post("/api/customer/v1/reservations/preemption")


### PR DESCRIPTION
## 🖊️ 1. Changes
- 모니터링을 하기 위한 설정 파일을 common 모듈의 global에 추가하였습니다.
- 예약 등록, 취소에 대한 Counted 기능을 추가하였습니다.
- 웨이팅 등록, 취소에 대한 Counted 기능을 추가하였습니다.
- 알림에 대한 Counted 기능을 추가하였습니다.
- 페이징 및 전체 조회에 대한 요청에 대해서 Timed를 추가하였습니다.

## 🖼️ 2. Screenshot
<img width="1431" alt="image" src="https://github.com/prgrms-be-devcourse/BE-04-DevTable/assets/74203371/550a0091-da1d-4124-98d7-5592f202dca2">


## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer

- Timer라는 기능과 Gauge 라는 기능이 있습니다. Timer는 해당 메서드의 실행 시간을 추적하는 기능을 하고, Gauge는 어떠한 수가 오르내릴 때 사용 할 수 있습니다. 예를 들어서 CPU 사용량, 메모리 사용량 같은 것처럼요!
- 하지만 저희 애플리케이션에는 재고 같은걸 따로 관리하지는 않아서 Gauge는 필요 한 것 같지 않다고 생각이 들었습니당. 음 특별히 사용한다면 어떠한 매장의 totalWaiting이나 totalReservation을 확인 할 때 사용 할 수도 있을 것 같네요.
- Timer는 원하시는 곳이 있다면 반영하도록 하겠습니다.
- **수정이 필요한 부분에 대해서는 TODO 처리를 해두었습니다.**

## ✅ 5. Plans
- [x] 예약 등록과 취소에 대한 Counted 기능 추가
- [x] 웨이팅 등록과 취소에 대한 Counted 기능 추가
- [x] 알림에 대한 Counted 기능 추가 
- [x] 페이징 및 전체 조회에 대한 timed 추가 
- [x] 그라파나에 대시보드 추가 